### PR TITLE
avocado.virt: Introduce templates

### DIFF
--- a/avocado/plugins/virt.py
+++ b/avocado/plugins/virt.py
@@ -18,6 +18,8 @@ Virtualization testing plugin.
 
 import os
 
+from argparse import FileType
+
 from avocado.core import output
 from avocado.utils import process
 from avocado.plugins import plugin
@@ -77,6 +79,9 @@ class VirtOptions(plugin.Plugin):
             default=defaults.disable_restore_image_job,
             help=('Do not restore the guest image before a test job '
                   'starts. Default: %s' % defaults.disable_restore_image_job))
+        virt_parser.add_argument(
+            '--qemu-template', nargs='?', type=FileType('r'),
+            help='Create qemu command line from a template')
 
         self.configured = True
 

--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -47,3 +47,9 @@ guest_password = '123456'
 
 disable_restore_image_test = False
 disable_restore_image_job = False
+
+qemu_template = """
+{qemu_bin}
+{avocado_defaults}
+{avocado_migration}
+"""

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -44,7 +44,7 @@ class VM(object):
     def __init__(self, params=None):
         self._popen = None
         self.params = params
-        self.devices = devices.QemuDevices(params)
+        self.devices = devices.QemuDevices(params, logger=self.log)
         self.logged = False
         self.remote = None
         self.uuid = uuid.uuid4()
@@ -170,7 +170,7 @@ class VM(object):
         while not network.is_port_free(migration_port, 'localhost'):
             migration_port += 1
         incoming_args = " -incoming %s:0:%d" % (migration_mode, migration_port)
-        clone.devices.add_args(incoming_args)
+        clone.devices.add_args('incoming', incoming_args)
         clone.power_on()
         uri = "%s:localhost:%d" % (migration_mode, migration_port)
         self.qmp("migrate", uri=uri)

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -39,6 +39,10 @@ class VirtTest(test.Test):
             params['avocado.args.run.guest_user'] = job.args.guest_user
         if job.args.guest_password:
             params['avocado.args.run.guest_password'] = job.args.guest_password
+        if job.args.qemu_template is not None:
+            params['avocado.args.run.qemu_template'] = job.args.qemu_template.read()
+        else:
+            params['avocado.args.run.qemu_template'] = defaults.qemu_template
 
         params['avocado.args.run.guest_image_restore_test'] = not job.args.disable_restore_image_test
 

--- a/examples/complex.tpl
+++ b/examples/complex.tpl
@@ -1,0 +1,10 @@
+/usr/bin/qemu-kvm
+-smp 2,sockets=2,cores=2,threads=2
+-m 1024
+-cpu SandyBridge
+-spice port=5900,addr=127.0.0.1,disable-ticketing,seamless-migration=on
+-device qxl-vga,id=video0
+{avocado_qmp_default}
+{avocado_drive_default}
+{avocado_net_default}
+{avocado_serial_default}

--- a/examples/default.tpl
+++ b/examples/default.tpl
@@ -1,0 +1,2 @@
+{qemu_bin}
+{avocado_defaults}

--- a/examples/migration.tpl
+++ b/examples/migration.tpl
@@ -1,0 +1,3 @@
+{qemu_bin}
+{avocado_defaults}
+{avocado_migration}

--- a/examples/sandbox.tpl
+++ b/examples/sandbox.tpl
@@ -1,0 +1,4 @@
+{qemu_bin}
+-sandbox on
+{avocado_defaults}
+{avocado_migration}


### PR DESCRIPTION
Introduce templates to create custom qemu command line invocations.
The templates are native Python string templates with custom
attributes that comes from the devices.py API.

The current attributes are:
- {qemu_bin}
- {avocado_fd_default}
- {avocado_qmp_default}
- {avocado_display_default}
- {avocado_vga_default}
- {avocado_drive_default}
- {avocado_net_default}
- {avocado_serial_default}
- {avocado_migration}
- {avocado_defaults}

The default template is stored in defaults.py.
Samples available in examples/*.tpl.

Here's a valid template:

{qemu_bin}
    -sandbox on
    {avocado_defaults}

The invocation from the command line:

$ avocado run --qemu-template example.tpl tests/qemu/boot.py

Signed-off-by: Rudá Moura rmoura@redhat.com
