### PR TITLE
avocado: Fix setup.py to use version 0.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 # pylint: disable=E0611
 from distutils.core import setup
 
-VERSION = '0.1.3'
+VERSION = '0.14.0'
 
 setup(name='avocado-virt',
       version=VERSION,


### PR DESCRIPTION
Fix this small bug in the setup.py code.
