### PR TITLE
avocado.virt.qemu.machine: Start QEMU process after init

### DIFF
--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -69,6 +69,7 @@ class VM(object):
 
         try:
             self._popen = process.SubProcess(cmd=cmdline)
+            self._popen.start()
             self._qmp.accept()
             self.serial_console = aexpect.ShellSession(
                 "nc -U %s" % self.serial_socket,


### PR DESCRIPTION
After https://github.com/avocado-framework/avocado/commit/9874c0b5e76aca6e3aaba26ed3a30d198a35aff6, we have to make the QEMU process to start. This patch fixes the problem.

This is a trivial fix I'm publishing to take it off the new version of the vm screenshots feature I'm going to submit.
