### PR TITLE
avocado.virt: Fix migration progress tracking logic

### DIFF
--- a/avocado/plugins/virt.py
+++ b/avocado/plugins/virt.py
@@ -93,6 +93,11 @@ class VirtOptions(plugin.Plugin):
             default=defaults.screendump_thread_interval,
             help=('Interval (s) used to produce the screendumps. '
                   'Default: %s' % defaults.screendump_thread_interval))
+        virt_parser.add_argument(
+            '--migrate-timeout', type=float,
+            default=defaults.migrate_timeout,
+            help=('Time (s) to wait until a QEMU migration is finished. '
+                  'Default: %s' % defaults.migrate_timeout))
         if VIDEO_ENCODING_SUPPORT:
             virt_parser.add_argument(
                 '--record-videos', action='store_true',

--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -53,3 +53,5 @@ screendump_thread_interval = 0.5
 
 video_encoding_enable = False
 video_encoding_jpeg_quality = 95
+
+migrate_timeout = 60.0

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -45,6 +45,8 @@ class VirtTest(test.Test):
             params['avocado.args.run.screendump_thread.enable'] = job.args.take_screendumps
         if job.args.screendump_interval:
             params['avocado.args.run.screendump_thread.interval'] = job.args.screendump_interval
+        if job.args.migrate_timeout:
+            params['avocado.args.run.migrate.timeout'] = job.args.migrate_timeout
 
         if hasattr(job.args, 'record_videos'):
             if getattr(job.args, 'record_videos'):


### PR DESCRIPTION
My original code considered any state that did not match
'active' to a migration completed state (we've been using
it for ages in virt-test), but now we have a new state,
'setup', that might appear for a little bit after the
migration process starts.

This way, we proceed and kill the src, failing this way
the migration process. This is wrong, and we should opt
for a saner way to verify whether migration ends:
- Get the output of 'info migrate'
- If it says 'completed', then everything is fine, let's
  end migration
- If it says 'failed', then the process obviously failed,
  let's end the test with a failure
- Every other status, we keep on waiting

If we get to the end of timeout and neither 'completed'
nor 'failed' appears, we fail the test saying that the
migration couldn't finish after the timeout window.

Let's also make this window configurable, and let people
to set it in the avocado command line.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
