### PR TITLE
Creates screendumps directory only when necessary.

### DIFF
--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -241,9 +241,6 @@ class VM(object):
         self.qmp(cmd='screendump', verbose=verbose, filename=filename)
 
     def _screendump_thread_start(self):
-        self.screendump_dir = utils_path.init_dir(os.path.join(self.logdir,
-                                                               'screendumps',
-                                                               self.short_id))
         thread_enable = 'avocado.args.run.screendump_thread.enable'
         self._screendump_thread_enable = self.params.get(thread_enable,
                                                          defaults.screendump_thread_enable)
@@ -251,6 +248,8 @@ class VM(object):
         self._video_enable = self.params.get(video_enable,
                                              defaults.video_encoding_enable)
         if self._screendump_thread_enable:
+            self.screendump_dir = utils_path.init_dir(
+                os.path.join(self.logdir, 'screendumps', self.short_id))
             self._screendump_terminate = threading.Event()
             self._screendump_thread = threading.Thread(target=self._take_screendumps,
                                                        name='VmScreendumps')


### PR DESCRIPTION
Avoid to create the screendumps directory inside the test result when not required, just when you pass the proper command line argument to create the screendumps.
