### PR TITLE
Empty arguments for avocado.virt.qemu.machine.VM class will not raise exception later.

### DIFF
--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -53,6 +53,8 @@ class VM(object):
     def __init__(self, uuid=None, params=None, logdir=None):
         self._popen = None
         self.pid = None
+        if params is None:
+            params = {}
         self.params = params
         self.devices = devices.QemuDevices(params)
         self.logged = False


### PR DESCRIPTION
Allows to use `avocado.virt.qemu.machine.VM` with empty parameters, so you can make use of it in command line, like:

```
>>> import avocado.virt.qemu import machine
>>> vm = machine.VM()
>>> vm.power_on()
>>> vm.power_off()
```

without raising exception of kind 'NoneType' object and 'get' attribute.

Signed-off-by: Rudá Moura rmoura@redhat.com
