### PR TITLE
avocado.virt.qemu: Code refactoring on QemuDevices class.

### DIFF
--- a/avocado/virt/qemu/devices.py
+++ b/avocado/virt/qemu/devices.py
@@ -16,6 +16,7 @@
 #
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 # Author: Stefan Hajnoczi <stefanha@redhat.com>
+# Author: Ruda Moura <rmoura@redhat.com>
 
 from avocado.utils import network
 from avocado.virt import defaults
@@ -26,71 +27,322 @@ class UnsupportedMigrationProtocol(Exception):
     pass
 
 
+class UnknownQemuDevice(Exception):
+    pass
+
+
+# Borg class by Alex Martelli
+class _Borg:
+
+    __shared_state = {}
+
+    def __init__(self):
+        self.__dict__ = self.__shared_state
+
+
+class PortTracker(_Borg):
+
+    '''Port tracker.'''
+
+    def __init__(self):
+        _Borg.__init__(self)
+        self.address = 'localhost'
+        self.start_port = 5000
+        if not hasattr(self, 'retained_ports'):
+            self._reset_retained_ports()
+
+    def __str__(self):
+        return 'Ports tracked: %r' % self.retained_ports
+
+    def _reset_retained_ports(self):
+        self.retained_ports = []
+
+    def register_port(self, port):
+        if ((port not in self.retained_ports) and
+           (network.is_port_free(port, self.address))):
+            self.retained_ports.append(port)
+        else:
+            raise ValueError('Port %d in use' % port)
+        return port
+
+    def find_free_port(self, start_port=None):
+        if start_port is None:
+            start_port = self.start_port
+        port = start_port
+        while ((port in self.retained_ports) or
+               (not network.is_port_free(port, self.address))):
+            port += 1
+        self.retained_ports.append(port)
+        return port
+
+    def release_port(self, port):
+        if port in self.retained:
+            self.retained.remove(port)
+
+
+class QemuDevice(object):
+
+    '''Abstract Qemu device.'''
+
+    name = 'qemu_device'
+
+    def __init__(self):
+        self._args = []
+        self.ports = PortTracker()
+
+    def __repr__(self):
+        return '%s(name=%r)' % (self.__class__.__name__, self.name)
+
+    def __str__(self):
+        return self.get_cmdline()
+
+    def get_cmdline(self):
+        return ' '.join(self._args).format(self=self)
+
+    def clone(self):
+        return self
+
+
+class QemuBinary(QemuDevice):
+
+    '''The Qemu binary.'''
+
+    name = 'qemu_binary'
+
+    def __init__(self, path='/bin/qemu-kvm'):
+        QemuDevice.__init__(self)
+        self.path = path
+        self._args = ['{self.path}']
+
+
+class QemuDeviceNoDefaults(QemuDevice):
+
+    '''Don't create default devices.'''
+
+    name = 'nodefaults'
+
+    def __init__(self):
+        QemuDevice.__init__(self)
+        self._args = ['-nodefaults']
+
+
+class QemuDeviceDisplay(QemuDevice):
+
+    '''Display options.'''
+
+    name = 'display'
+
+    def __init__(self, kind='none'):
+        QemuDevice.__init__(self)
+        self.kind = kind
+        self._args = ['-display {self.kind}']
+
+
+class QemuDeviceVGA(QemuDevice):
+
+    '''Video card.'''
+
+    name = 'vga'
+
+    def __init__(self, video_card='none'):
+        QemuDevice.__init__(self)
+        self.video_card = video_card
+        self._args = ['-vga {self.video_card}']
+
+
+class QemuDeviceVNC(QemuDevice):
+
+    '''VNC Server.'''
+
+    name = 'vnc'
+
+    def __init__(self, port):
+        QemuDevice.__init__(self)
+        self.port = port
+        self._args = ['-vnc :{self.port}']
+
+    def clone(self):
+        self.port = self.ports.find_free_port(self.port)
+        return self
+
+
+class QemuDeviceQMP(QemuDevice):
+
+    '''QMP monitor.'''
+
+    name = 'qmp'
+
+    def __init__(self, socket):
+        QemuDevice.__init__(self)
+        self.socket = socket
+        self._args = ['-chardev socket,id=mon,path={self.socket}',
+                      '-mon chardev=mon,mode=control']
+
+
+class QemuDeviceSerial(QemuDevice):
+
+    '''Serial port.'''
+
+    name = 'serial'
+
+    def __init__(self, socket, device_id='avocado_serial'):
+        QemuDevice.__init__(self)
+        self.socket = socket
+        self.device_id = device_id
+        self._args = ['-chardev socket,id={self.device_id},path={self.socket},server,nowait',
+                      '-device isa-serial,chardev={self.device_id}']
+
+
+class QemuDeviceFD(QemuDevice):
+
+    '''Floppy drive.'''
+
+    name = 'fd'
+
+    def __init__(self, fd, fdset, opaque, opts):
+        QemuDevice.__init__(self)
+        self.fd = fd
+        self.set = fdset
+        self.opaque = opaque
+        self._args = ['-add-fd fd={self.fd} set={self.set} opaque={self.opaque}']
+        if opts:
+            self._args.extend(opts)
+
+
+class QemuDeviceDrive(QemuDevice):
+
+    '''Disk drive.'''
+
+    name = 'drive'
+
+    def __init__(self, drive_file, device_type='virtio-blk-pci',
+                 device_id='avocado_image', drive_id='device_avocado_image'):
+        QemuDevice.__init__(self)
+        self.drive_file = drive_file
+        self.device_type = device_type
+        self.device_id = device_id
+        self.drive_id = drive_id
+        self._args = ['-drive id={self.drive_id},if=none,file={self.drive_file}',
+                      '-device {self.device_type},id={self.device_id},drive={self.drive_id}']
+
+
+class QemuDeviceNetwork(QemuDevice):
+
+    '''Network device.'''
+
+    name = 'network'
+
+    def __init__(self, redir_port,
+                 netdev_type='user', device_type='virtio-net-pci',
+                 device_id='avocado_nic', nic_id='device_avocado_nic'):
+        QemuDevice.__init__(self)
+        self.redir_port = redir_port
+        self.netdev_type = netdev_type
+        self.device_type = device_type
+        self.device_id = device_id
+        self.nic_id = nic_id
+        self._args = ['-device {self.device_type},id={self.device_id},netdev={self.nic_id}',
+                      '-netdev {self.netdev_type},id={self.nic_id},hostfwd=tcp::{self.ports.redir_port}-:22']
+
+    def clone(self):
+        self.ports.redir_port = self.ports.find_free_port(self.ports.redir_port)
+        self.redir_port = self.ports.redir_port
+        return self
+
+
+class QemuDeviceIncoming(QemuDevice):
+
+    '''Incoming migration.'''
+
+    name = 'incoming'
+
+    def __init__(self, protocol='tcp', port=5000):
+        QemuDevice.__init__(self)
+        self.protocol = protocol
+        self.port = port
+        self._args = ['-incoming {self.protocol}:0:{self.port}']
+
+
 class QemuDevices(object):
 
     def __init__(self, params=None):
         self.params = params
         self.qemu_bin = path.get_qemu_binary(params)
-        self.redir_port = None
-        self._args = [self.qemu_bin]
-        self._op_record = []
-        self._allocated_ports = []
+        self.devices = [QemuBinary(self.qemu_bin)]
+        self.ports = PortTracker()
+        self._qemu_device_classes = list(self._get_qemu_device_classes())
 
-    def find_free_port(self, start_port, address="localhost"):
-        port = start_port
-        while ((port in self._allocated_ports) or
-               (not network.is_port_free(port, address))):
-            port += 1
-        self._allocated_ports.append(port)
-        return port
+    def __str__(self):
+        return self.get_cmdline()
 
-    def add_args(self, *args):
-        self._args.extend(args)
+    def _get_qemu_device_classes(self):
+        return (cls for cls in QemuDevice.__subclasses__())
+
+
+    def add_device(self, name_or_class, **kwargs):
+        dev = None
+        for cls in self._qemu_device_classes:
+            if name_or_class == cls.name or name_or_class == cls:
+                dev = cls(**kwargs)
+                self.devices.append(dev)
+        if dev is None:
+            raise UnknownQemuDevice(name_or_class)
+
+    def remove_device(self, name_or_class):
+        not_found = True
+        for dev in list(self.devices):
+            if dev.name == name_or_class or dev.__class__ == name_or_class:
+                self.devices.remove(dev)
+                not_found = False
+                break
+        if not_found:
+            raise ValueError('%s not in devices' % name_or_class)
+
+    def has_device(self, name_or_class):
+        not_found = False
+        for dev in self.devices:
+            if dev.name == name_or_class or dev.__class__ == name_or_class:
+                not_found = True
+                break
+        return not_found
 
     def get_cmdline(self):
-        return ' '.join(self._args)
+        devices = [str(dev) for dev in self.devices]
+        return ' '.join(devices)
 
     def clone(self, params=None):
-        new_devices = QemuDevices(params)
-        new_devices._allocated_ports = self._allocated_ports
-        for op, args in self._op_record:
-            method = getattr(new_devices, op)
-            method(**args)
-        return new_devices
-
-    def add_fd(self, fd, fdset, opaque, opts=''):
-        options = ['fd=%d' % fd,
-                   'set=%d' % fdset,
-                   'opaque=%s' % opaque]
-        if opts:
-            options.append(opts)
-
-        self.add_args('-add-fd', ','.join(options))
-
-    def add_qmp_monitor(self, monitor_socket):
-        self.add_args('-chardev',
-                      'socket,id=mon,path=%s' % monitor_socket,
-                      '-mon', 'chardev=mon,mode=control')
-
-    def add_display(self, value='none'):
-        self._op_record.append(['add_display', {'value': value}])
-        self.add_args('-display', value)
-
-    def add_vga(self, value='none'):
-        self._op_record.append(['add_vga', {'value': value}])
-        self.add_args('-vga', value)
+        new_qemu_devices = QemuDevices(params)
+        new_qemu_devices.devices = list(self.devices)
+        for exclude in ['qmp', 'serial', 'fd', 'incoming']:
+            try:
+                new_qemu_devices.remove_device(exclude)
+            except ValueError:
+                pass
+        for dev in new_qemu_devices.devices:
+            dev.clone()
+        return new_qemu_devices
 
     def add_nodefaults(self, value='none'):
-        self._op_record.append(['add_nodefaults', {}])
-        self.add_args('-nodefaults')
+        self.add_device('nodefaults')
+
+    def add_display(self, kind='none'):
+        self.add_device('display', kind=kind)
+
+    def add_vga(self, video_card='none'):
+        self.add_device('vga', video_card=video_card)
 
     def add_vnc(self, port=None):
         if port is None:
-            self.vnc_port = self.find_free_port(5900)
+            self.port = self.ports.find_free_port(5900)
         else:
-            self.vnc_port = port
-        self._op_record.append(['add_vnc', {'port': port}])
-        self.add_args('-vnc', ":%s" % self.vnc_port)
+            self.port = self._port.register_port(port)
+        self.add_device('vnc', port=self.port)
+
+    def add_qmp_monitor(self, monitor_socket):
+        self.add_device('qmp', socket=monitor_socket)
+
+    def add_fd(self, fd, fdset, opaque, opts=None):
+        self.add_device('fd', fd=fd, fdset=fdset, opaque=opaque, opts=opts)
 
     def add_drive(self, drive_file=None, device_type='virtio-blk-pci',
                   device_id='avocado_image', drive_id='device_avocado_image'):
@@ -107,39 +359,24 @@ class QemuDevices(object):
         if drive_file is None:
             drive_file = self.params.get('avocado.args.run.guest_image_path',
                                          defaults.guest_image_path)
-
-        self._op_record.append(['add_drive', {'drive_file': drive_file,
-                                              'device_type': device_type,
-                                              'device_id': device_id,
-                                              'drive_id': drive_id}])
-        self.add_args('-drive',
-                      'id=%s,if=none,file=%s' %
-                      (drive_id, drive_file),
-                      '-device %s,id=%s,drive=%s' %
-                      (device_type, device_id, drive_id))
+        self.add_device('drive', drive_file=drive_file, device_type=device_type,
+                        device_id=device_id, drive_id=drive_id)
 
     def add_net(self, netdev_type='user', device_type='virtio-net-pci',
                 device_id='avocado_nic', nic_id='device_avocado_nic'):
-        self._op_record.append(['add_net', {'netdev_type': netdev_type,
-                                            'device_type': device_type,
-                                            'device_id': device_id,
-                                            'nic_id': nic_id}])
-        self.redir_port = self.find_free_port(5000)
-        self.add_args('-device %s,id=%s,netdev=%s' %
-                      (device_type, device_id, nic_id),
-                      '-netdev %s,id=%s,hostfwd=tcp::%s-:22' %
-                      (netdev_type, nic_id, self.redir_port))
+        self.ports.redir_port = self.ports.find_free_port(5000)
+        self.add_device('network', redir_port=self.ports.redir_port,
+                        netdev_type=netdev_type, device_type=device_type,
+                        device_id=device_id, nic_id=nic_id)
 
     def add_serial(self, serial_socket, device_id='avocado_serial'):
-        self.add_args('-chardev socket,id=%s,path=%s,server,nowait' % (device_id, serial_socket))
-        self.add_args('-device isa-serial,chardev=%s' % (device_id))
+        self.add_device('serial', socket=serial_socket, device_id=device_id)
 
     def add_incoming(self, protocol):
         if protocol == 'tcp':
-            self.migration_tcp_port = self.find_free_port(5000)
-            self.add_args("-incoming %s:0:%d" %
-                          (protocol, self.migration_tcp_port))
+            self.ports.migration_tcp_port = self.ports.find_free_port(5000)
+            self.add_device('incoming', protocol=protocol, port=self.ports.migration_tcp_port)
         else:
             msg = 'Migration %s still unsupported' % protocol
             raise UnsupportedMigrationProtocol(msg)
-        return self.migration_tcp_port
+        return self.ports.migration_tcp_port

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -171,7 +171,7 @@ class VM(object):
             if password is None:
                 password = self.params.get('avocado.args.run.guest_password')
             if port is None:
-                port = self.devices.redir_port
+                port = self.devices.ports.redir_port
             self.log('Login (Remote) -> '
                      '(hostname=%s, username=%s, password=%s, port=%s)'
                      % (hostname, username, password, port))


### PR DESCRIPTION
Improvements that this code refactory brings:
- Introduce QemuDevice\* subclasses for every devices that
  avocado-virt handles (like, vnc, network, qmp, etc.).
- The QemuDevice\* subclasses allows to represent the command
  line options as strings and to allow pick specific values,
  like the port number of a device.
- The QemuDevice\* subclasses have a clone() method for migrating.
- Introduce the Port Tracker, to keep track on ports in use.
- Try to keep the same API of avocado-virt, so the tests don't break.

Signed-off-by: Rudá Moura rmoura@redhat.com
