### PR TITLE
avocado.virt.qemu: Introduce qemu templates.

### DIFF
--- a/avocado/plugins/virt.py
+++ b/avocado/plugins/virt.py
@@ -18,6 +18,8 @@ Virtualization testing plugin.
 
 import os
 
+from argparse import FileType
+
 from avocado.core import output
 from avocado.utils import process
 from avocado.plugins import plugin
@@ -112,6 +114,9 @@ class VirtOptions(plugin.Plugin):
                       'setting, the larger the result video will be '
                       '(maximum 100). Default: %s' %
                       defaults.video_encoding_jpeg_quality))
+        virt_parser.add_argument(
+            '--qemu-template', nargs='?', type=FileType('r'),
+            help='Create qemu command line from a template')
 
         self.configured = True
 

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -45,6 +45,8 @@ class VirtTest(test.Test):
             params['avocado.args.run.screendump_thread.interval'] = job.args.screendump_interval
         if job.args.migrate_timeout:
             params['avocado.args.run.migrate.timeout'] = job.args.migrate_timeout
+        if job.args.qemu_template:
+            params['avocado.args.run.qemu_template'] = job.args.qemu_template.read()
 
         if hasattr(job.args, 'record_videos'):
             if getattr(job.args, 'record_videos'):

--- a/examples/complex.tpl
+++ b/examples/complex.tpl
@@ -1,0 +1,10 @@
+/usr/bin/qemu-kvm
+-smp 2,sockets=2,cores=2,threads=2
+-m 1024
+-cpu SandyBridge
+-spice port=5900,addr=127.0.0.1,disable-ticketing,seamless-migration=on
+-device qxl-vga,id=video0
+{avocado_qmp}
+{avocado_drive}
+{avocado_network}
+{avocado_serial}

--- a/examples/default.tpl
+++ b/examples/default.tpl
@@ -1,0 +1,1 @@
+{avocado_defaults}

--- a/examples/migration.tpl
+++ b/examples/migration.tpl
@@ -1,0 +1,3 @@
+{avocado_qemu_binary}
+{avocado_devices}
+{avocado_migration}

--- a/examples/sandbox.tpl
+++ b/examples/sandbox.tpl
@@ -1,0 +1,3 @@
+{avocado_qemu_binary} -sandbox on
+{avocado_devices}
+{avocado_migration}


### PR DESCRIPTION
Introduce qemu templates to create custom command line invocations.
The templates are native Python string templates with custom
tags that comes from values of `avocado.virt.qemu.devices` API.

The current tags are:
- {avocado_defaults}  all options, with qemu binary path included
- {avocado_qemu_binary}  the qemu binary path
- {avocado_devices}  the devices, without the qemu binary path
- {avocado_qmp}  qmp device
- {avocado_display}  display device
- {avocado_vga}  vga device
- {avocado_drive} drive device
- {avocado_network}  network device
- {avocado_serial}  serial device
- {avocado_vnc}  vnc device
- {avocado_fd}  floppy disk device

Some tags accepts to get internal values. For example,
from `avocado_drive` you can get the default disk image
with `{avocado_drive.drive_file}`.

Samples available in examples/*.tpl.

Here's a valid template:

```
{avocado_qemu_binary}
    -sandbox on -m 64
    {avocado_devices}
```

The invocation from the command line:

`avocado run --qemu-template example.tpl tests/qemu/boot.py`

Signed-off-by: Rudá Moura rmoura@redhat.com
