### PR TITLE
[V2] avocado.virt.qemu.devices: Add GenericDevice to the QEMU cmdline

### DIFF
--- a/avocado/virt/qemu/devices.py
+++ b/avocado/virt/qemu/devices.py
@@ -104,6 +104,16 @@ class QemuDevice(object):
         return self
 
 
+class QemuDeviceGeneric(QemuDevice):
+
+    name = 'generic'
+
+    def __init__(self, cmdline):
+        QemuDevice.__init__(self)
+        self.cmdline = cmdline
+        self._args = cmdline.split()
+
+
 class QemuBinary(QemuDevice):
 
     """
@@ -399,3 +409,6 @@ class QemuDevices(object):
             msg = 'Migration %s still unsupported' % protocol
             raise UnsupportedMigrationProtocol(msg)
         return self.ports.migration_tcp_port
+
+    def add_cmdline(self, cmdline):
+        self.add_device('generic', cmdline=cmdline)


### PR DESCRIPTION
Create a method to append an arbitrary cmdline to an already
existing QEMU cmdline, add_cmdline. That method will be useful
for many tests that seek to add devices to a QEMU based VM before
boot.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>