### PR TITLE
[V1] Add config file for virt plugin

### DIFF
--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -55,7 +55,7 @@ except SettingsError:
 
 # The defaults are related to the default image used (JeOS)
 try:
-    qemu_img_bin = settings.get_value('virt.guest', 'image_path')
+    guest_image_path = settings.get_value('virt.guest', 'image_path')
 except SettingsError:
     guest_image_path = data_dir.get_datafile_path('images',
                                                   'jeos-20-64.qcow2')

--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -17,41 +17,59 @@ Default values used in tests and plugin code.
 """
 
 from avocado.core import data_dir
+from avocado.settings import settings
+from avocado.settings import SettingsError
 from avocado.virt.qemu import path
 
 try:
-    qemu_bin = path.get_qemu_binary()
-except:
-    qemu_bin = 'qemu'
+    qemu_bin = settings.get_value('virt.qemu.paths', 'qemu_bin')
+except SettingsError:
+    try:
+        qemu_bin = path.get_qemu_binary()
+    except path.QEMUCmdNotFoundError:
+        qemu_bin = 'qemu'
 
 try:
-    qemu_dst = path.get_qemu_dst_binary()
-except:
-    qemu_dst = 'qemu'
+    qemu_dst = settings.get_value('virt.qemu.paths', 'qemu_dst_bin')
+except SettingsError:
+    try:
+        qemu_dst = path.get_qemu_dst_binary()
+    except path.QEMUCmdNotFoundError:
+        qemu_dst = 'qemu'
 
 try:
-    qemu_img_bin = path.get_qemu_img_binary()
-except:
-    qemu_img_bin = 'qemu-img'
+    qemu_img_bin = settings.get_value('virt.qemu.paths', 'qemu_img_bin')
+except SettingsError:
+    try:
+        qemu_img_bin = path.get_qemu_img_binary()
+    except path.QEMUCmdNotFoundError:
+        qemu_img_bin = 'qemu-img'
 
 try:
-    qemu_io_bin = path.get_qemu_io_binary()
-except:
-    qemu_io_bin = 'qemu-io'
+    qemu_img_bin = settings.get_value('virt.qemu.paths', 'qemu_io_bin')
+except SettingsError:
+    try:
+        qemu_io_bin = path.get_qemu_io_binary()
+    except path.QEMUCmdNotFoundError:
+        qemu_io_bin = 'qemu-io'
 
 # The defaults are related to the default image used (JeOS)
-guest_image_path = data_dir.get_datafile_path('images',
-                                              'jeos-20-64.qcow2')
-guest_user = 'root'
-guest_password = '123456'
+try:
+    qemu_img_bin = settings.get_value('virt.guest', 'image_path')
+except SettingsError:
+    guest_image_path = data_dir.get_datafile_path('images',
+                                                  'jeos-20-64.qcow2')
 
-disable_restore_image_test = False
-disable_restore_image_job = False
+guest_user = settings.get_value('virt.guest', 'user', default='root')
+guest_password = settings.get_value('virt.guest', 'password', default='123456')
 
-screendump_thread_enable = False
-screendump_thread_interval = 0.5
+disable_restore_image_test = settings.get_value('virt.restore', 'disable_for_test', default=False)
+disable_restore_image_job = settings.get_value('virt.restore', 'disable_for_job', default=False)
 
-video_encoding_enable = False
-video_encoding_jpeg_quality = 95
+screendump_thread_enable = settings.get_value('virt.screendumps', 'enable', default=False)
+screendump_thread_interval = settings.get_value('virt.screendumps', 'interval', default=0.5)
 
-migrate_timeout = 60.0
+video_encoding_enable = settings.get_value('virt.videos', 'enable', default=False)
+video_encoding_jpeg_quality = settings.get_value('virt.videos', 'jpeg_conversion_quality', default=95)
+
+migrate_timeout = settings.get_value('virt.qemu.migrate', 'timeout', default=60.0)

--- a/avocado/virt/qemu/path.py
+++ b/avocado/virt/qemu/path.py
@@ -50,9 +50,9 @@ def get_qemu_binary(params=None):
     then, if nothing found, look in the system $PATH.
     """
     if params is not None:
-        params_qemu = params.get('avocado.args.run.qemu_bin')
+        params_qemu = params.get('virt.qemu.paths.qemu_bin')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'test param avocado.args.run.qemu_bin')
+            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_bin')
 
     env_qemu = os.environ.get('QEMU')
     if env_qemu is not None:
@@ -74,9 +74,9 @@ def get_qemu_dst_binary(params=None):
     This is for use in migration tests.
     """
     if params is not None:
-        params_qemu = params.get('avocado.args.run.qemu_dst_bin')
+        params_qemu = params.get('virt.qemu.paths.qemu_dst_bin')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'test param avocado.args.run.qemu_dst_bin')
+            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_dst_bin')
 
     env_qemu = os.environ.get('QEMU_DST')
     if env_qemu is not None:
@@ -93,9 +93,9 @@ def get_qemu_dst_binary(params=None):
 
 def get_qemu_img_binary(params=None):
     if params is not None:
-        params_qemu = params.get('avocado.args.run.qemu_img_bin')
+        params_qemu = params.get('virt.qemu.paths.qemu_img_bin')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'test param avocado.args.run.qemu_img_bin')
+            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_img_bin')
 
     env_qemu = os.environ.get('QEMU_IMG')
     if env_qemu is not None:
@@ -111,9 +111,9 @@ def get_qemu_img_binary(params=None):
 
 def get_qemu_io_binary(params=None):
     if params is not None:
-        params_qemu = params.get('avocado.args.run.qemu_io_bin')
+        params_qemu = params.get('virt.qemu.paths.qemu_io_bin')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'test param avocado.args.run.qemu_io_bin')
+            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_io_bin')
 
     env_qemu = os.environ.get('QEMU_IO')
     if env_qemu is not None:

--- a/avocado/virt/utils/video.py
+++ b/avocado/virt/utils/video.py
@@ -12,7 +12,7 @@
 # Copyright (C) 2014 Red Hat Inc
 
 """
-Encoder transforms screenshots taken during a test into a HTML 5
+Encoder transforms screenshots taken during a test into an HTML 5
 compatible video, so that one can watch the screen activity of the
 whole test from inside your own browser.
 

--- a/etc/avocado/conf.d/virt.conf
+++ b/etc/avocado/conf.d/virt.conf
@@ -1,0 +1,20 @@
+[virt.guest]
+image_path =
+user = root
+password = 123456
+[virt.restore]
+disable_for_job = False
+disable_for_test = False
+[virt.screendumps]
+enable = False
+interval = 0.5
+[virt.videos]
+enable = False
+jpeg_conversion_quality = 95
+[virt.qemu.paths]
+qemu_bin =
+qemu_dst_bin =
+qemu_img_bin =
+qemu_io_bin =
+[virt.qemu.migrate]
+timeout = 60.0


### PR DESCRIPTION
Add a config file for the virtualization plugin. Let users to configure aspects of the virt plugin through their `~/.config/avocado/avocado.conf` files.