### PR TITLE
avocado.virt.qemu.machine: Fix username and password path

### DIFF
--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -195,9 +195,9 @@ class VM(object):
             if hostname is None:
                 hostname = socket.gethostbyname(socket.gethostname())
             if username is None:
-                username = self.params.get('avocado.args.run.guest_user')
+                username = self.params.get('virt.guest.user')
             if password is None:
-                password = self.params.get('avocado.args.run.guest_password')
+                password = self.params.get('virt.guest.password')
             if port is None:
                 port = self.devices.ports.redir_port
             self.log('Login (Remote) -> '


### PR DESCRIPTION
The username and password has new params location.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>