### PR TITLE
Couple of adjustements to make avocado-virt simpler to start with

### DIFF
--- a/avocado/virt/qemu/devices.py
+++ b/avocado/virt/qemu/devices.py
@@ -183,7 +183,7 @@ class QemuDeviceVNC(QemuDevice):
         self._args = ['-vnc :{self.port}']
 
     def clone(self):
-        self.port = self.ports.find_free_port(self.port)
+        self.port = self.ports.find_free_port(self.port + 5900) - 5900
         return self
 
 
@@ -365,7 +365,7 @@ class QemuDevices(object):
             port = self.ports.find_free_port(5900)
         else:
             self._port.register_port(port)
-        self.add_device('vnc', port=port)
+        self.add_device('vnc', port=port - 5900)    # vnc :0 == port 5900
 
     def add_qmp_monitor(self, monitor_socket):
         self.add_device('qmp', socket=monitor_socket)

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -190,7 +190,7 @@ class VM(object):
         self.hmp_qemu_io(drive, 'remove_break bp_%s' % drive)
 
     def login_remote(self, hostname=None, username=None, password=None,
-                     port=None):
+                     port=None, timeout=360):
         if not self.logged:
             if hostname is None:
                 hostname = socket.gethostbyname(socket.gethostname())
@@ -203,7 +203,8 @@ class VM(object):
             self.log('Login (Remote) -> '
                      '(hostname=%s, username=%s, password=%s, port=%s)'
                      % (hostname, username, password, port))
-            self.remote = remote.Remote(hostname, username, password, port)
+            self.remote = remote.Remote(hostname, username, password, port,
+                                        timeout=timeout)
             res = self.remote.uptime()
             if res.succeeded:
                 self.logged = True

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -195,9 +195,9 @@ class VM(object):
             if hostname is None:
                 hostname = socket.gethostbyname(socket.gethostname())
             if username is None:
-                username = self.params.get('avocado.args.run.guest_user')
+                username = self.params.get('virt.guest.user')
             if password is None:
-                password = self.params.get('avocado.args.run.guest_password')
+                password = self.params.get('virt.guest.password')
             if port is None:
                 port = self.devices.ports.redir_port
             self.log('Login (Remote) -> '

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -130,7 +130,6 @@ class VirtTest(test.Test):
             self.restore_guest_images()
         self.vm = machine.VM(params=self.params, logdir=self.logdir)
         self.vm.devices.add_nodefaults()
-        self.vm.devices.add_display('none')
         self.vm.devices.add_vga('std')
         self.vm.devices.add_vnc()
         self.vm.devices.add_drive()


### PR DESCRIPTION
Hi @lmr, @ruda,

this pull request tries to remove obstacles I popped-up when playing with avocado-virt. There is still one thing I need to investigate and fix. When the test fails (eg. `raise Exception()` as first thing in boot test's `clenaup()`, avocado hangs in `avocado.core.output.Paginator.__del__`. When I disable paginator, it works fine (I read what it should do but in reality I didn't notice difference, do we really need it? Isn't it just an unnecessary thing which can get wrong?)

Regards,
Lukáš