### PR TITLE
virt.qemu.path: Use avocado.utils.path.find_command().

### DIFF
--- a/avocado/plugins/virt_bootstrap.py
+++ b/avocado/plugins/virt_bootstrap.py
@@ -22,6 +22,7 @@ from avocado.utils import download
 from avocado.utils import path
 from avocado.utils import crypto
 from avocado.utils import process
+from avocado.utils import path as utils_path
 
 
 class VirtBootstrap(plugin.Plugin):
@@ -44,9 +45,9 @@ class VirtBootstrap(plugin.Plugin):
         view = output.View(app_args=args)
         view.notify(event='message', msg='Probing your system for test requirements')
         try:
-            process.find_command('7za')
+            utils_path.find_command('7za')
             view.notify(event='minor', msg='7zip present')
-        except process.CmdNotFoundError:
+        except utils_path.CmdNotFoundError:
             view.notify(event='warning',
                         msg=("7za not installed. You may "
                              "install 'p7zip' (or the "

--- a/avocado/virt/qemu/path.py
+++ b/avocado/virt/qemu/path.py
@@ -20,7 +20,7 @@ Library used to retrieve qemu paths from params or environment.
 
 import os
 
-from avocado.utils import process
+from avocado.utils import path as utils_path
 
 _QEMU_CANDIDATE_NAMES = ['qemu-kvm', 'qemu-system-x86_64', 'qemu']
 
@@ -60,8 +60,8 @@ def get_qemu_binary(params=None):
 
     for c in _QEMU_CANDIDATE_NAMES:
         try:
-            return process.find_command(c)
-        except process.CmdNotFoundError:
+            return utils_path.find_command(c)
+        except utils_path.CmdNotFoundError:
             pass
 
     raise QEMUCmdNotFoundError('qemu')
@@ -84,8 +84,8 @@ def get_qemu_dst_binary(params=None):
 
     for c in _QEMU_CANDIDATE_NAMES:
         try:
-            return process.find_command(c)
-        except process.CmdNotFoundError:
+            return utils_path.find_command(c)
+        except utils_path.CmdNotFoundError:
             pass
 
     raise QEMUCmdNotFoundError('qemu alternate destination')
@@ -102,8 +102,8 @@ def get_qemu_img_binary(params=None):
         return _validate_path(env_qemu, 'env variable $QEMU_IMG')
 
     try:
-        return process.find_command('qemu-img')
-    except process.CmdNotFoundError:
+        return utils_path.find_command('qemu-img')
+    except utils_path.CmdNotFoundError:
         pass
 
     raise QEMUCmdNotFoundError('qemu-img')
@@ -120,8 +120,8 @@ def get_qemu_io_binary(params=None):
         return _validate_path(env_qemu, 'env variable $QEMU_IO')
 
     try:
-        return process.find_command('qemu-io')
-    except process.CmdNotFoundError:
+        return utils_path.find_command('qemu-io')
+    except utils_path.CmdNotFoundError:
         pass
 
     raise QEMUCmdNotFoundError('qemu-io')


### PR DESCRIPTION
From a recent API change in Avocado (see https://github.com/avocado-framework/avocado/pull/413), the utility function find_command()
has been moved from avocado.utils.process to avocado.utils.path,
so we're going to use this new module location.

Signed-off-by: Rudá Moura <rmoura@redhat.com>