### PR TITLE
video enconding: get the quality encoding value as an integer

### DIFF
--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -70,6 +70,6 @@ screendump_thread_enable = settings.get_value('virt.screendumps', 'enable', defa
 screendump_thread_interval = settings.get_value('virt.screendumps', 'interval', default=0.5)
 
 video_encoding_enable = settings.get_value('virt.videos', 'enable', default=False)
-video_encoding_jpeg_quality = settings.get_value('virt.videos', 'jpeg_conversion_quality', default=95)
+video_encoding_jpeg_quality = settings.get_value('virt.videos', 'jpeg_conversion_quality', default=95, key_type=int)
 
 migrate_timeout = settings.get_value('virt.qemu.migrate', 'timeout', default=60.0)


### PR DESCRIPTION
Depending on how the enconding quality settings make into the PIL library,
it may cause the following error:

```
Traceback (most recent call last):
  File "../avocado-virt-tests/qemu/boot.py", line 31, in cleanup
    self.vm.power_off()
  ...
  File "/home/cleber/src/avocado/avocado/virt/utils/video.py", line 83, in convert_to_jpg
    i.save(jpg_file, format="JPEG", quality=quality)
  File "/usr/lib64/python2.7/site-packages/PIL/Image.py", line 1460, in save
    save_handler(self, fp, filename)
  File "/usr/lib64/python2.7/site-packages/PIL/JpegImagePlugin.py", line 480, in _save
    raise ValueError("Invalid quality setting")
ValueError: Invalid quality setting
```

Getting the value from the configuration file as an integer solves that.

Signed-off-by: Cleber Rosa <crosa@redhat.com>