### PR TITLE
virt: Fix misleading variable

### DIFF
--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -111,7 +111,7 @@ class VM(object):
         self.serial_socket = tempfile.mktemp()
         self.devices.add_serial(self.serial_socket)
 
-        tmpl = self.params.get('virt.qemu.template.path')
+        tmpl = self.params.get('virt.qemu.template.contents')
 
         if tmpl is None:
             cmdline = self.devices.get_cmdline()

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -77,7 +77,8 @@ class VirtTest(test.Test):
                 params['virt.qemu.migrate.timeout'] = defaults.migrate_timeout
 
             if job.args.qemu_template:
-                params['virt.qemu.template.path'] = job.args.qemu_template.read()
+                params['virt.qemu.template.contents'] = \
+                    job.args.qemu_template.read()
 
             if hasattr(job.args, 'record_videos'):
                 if getattr(job.args, 'record_videos'):


### PR DESCRIPTION
As pointed out by Rudá, virt.qemu.template.path is not a
path, but the contents of the template file itself. Let's
change virt.qemu.template.path to virt.qemu.template.contents.

CC: Rudá Moura <rmoura@redhat.com>
Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>