### PR TITLE
avocado.virt.qemu: Fix use of parameters inside virt plugin

### DIFF
--- a/avocado/virt/qemu/devices.py
+++ b/avocado/virt/qemu/devices.py
@@ -387,7 +387,7 @@ class QemuDevices(object):
         :param drive_id: String identifying the newly added drive.
         """
         if drive_file is None:
-            drive_file = self.params.get('avocado.args.run.guest_image_path',
+            drive_file = self.params.get('virt.guest.image_path',
                                          defaults.guest_image_path)
         self.add_device('drive', drive_file=drive_file, device_type=device_type,
                         device_id=device_id, drive_id=drive_id)

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -246,7 +246,7 @@ class VM(object):
         clone.power_on()
         uri = "%s:localhost:%d" % (protocol, migration_port)
         self.qmp("migrate", uri=uri)
-        migrate_timeout = self.params.get('avocado.args.run.migrate.timeout', defaults.migrate_timeout)
+        migrate_timeout = self.params.get('virt.qemu.migrate.timeout', defaults.migrate_timeout)
         migrate_result = wait.wait_for(migrate_complete, timeout=migrate_timeout,
                                        text='Waiting for migration to complete')
         if migrate_result is None:
@@ -275,10 +275,10 @@ class VM(object):
         self.qmp(cmd='screendump', verbose=verbose, filename=filename)
 
     def _screendump_thread_start(self):
-        thread_enable = 'avocado.args.run.screendump_thread.enable'
+        thread_enable = 'virt.screendumps.enable'
         self._screendump_thread_enable = self.params.get(thread_enable,
                                                          defaults.screendump_thread_enable)
-        video_enable = 'avocado.args.run.video_encoding.enable'
+        video_enable = 'virt.videos.enable'
         self._video_enable = self.params.get(video_enable,
                                              defaults.video_encoding_enable)
         if self._screendump_thread_enable:
@@ -293,7 +293,7 @@ class VM(object):
         """
         Take screendumps on regular intervals.
         """
-        timeout = self.params.get('avocado.args.run.screendump_thread.interval',
+        timeout = self.params.get('virt.screendumps.interval',
                                   defaults.screendump_thread_interval)
         dump_list = sorted(os.listdir(self.screendump_dir))
         if dump_list:


### PR DESCRIPTION
Turns out we haven't updated all references to the new
parameters in the virt plugin code, leading to some options
in the command line that won't have an effect, such as
--take-screendumps and --record-videos. Let's fix that.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>