### PR TITLE
Test API:  Refactory plugins location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.project
+.pydevproject
+.settings
+.coverage
+.idea/*
+coverage.xml
+xunit.xml
+tmp/*
+logs/*
+*.pyc
+*~
+tags
+cscope.*
+build
+sysinfo-*
+MANIFEST
+dist

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON=`which python`
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/avocado-virt
 PROJECT=avocado
-VERSION="0.1.0"
+VERSION="0.24.0"
 
 all:
 	@echo "make source - Create source package"

--- a/avocado-virt.spec
+++ b/avocado-virt.spec
@@ -1,6 +1,6 @@
 Summary: Avocado Virt Plugin
 Name: avocado-virt
-Version: 0.23.0
+Version: 0.24.0
 Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
@@ -41,6 +41,9 @@ during avocado virt tests.
 %{python_sitelib}/avocado/virt/utils/video.py*
 
 %changelog
+* Mon May 18 2015 Ruda Moura <rmoura@redhat.com> - 0.24.0-1
+- New upstream release
+
 * Mon Apr 21 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.23.0-1
 - New upstream release
 

--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -21,8 +21,8 @@ import os
 from argparse import FileType
 
 from avocado.core import output
+from avocado.core.plugins import plugin
 from avocado.utils import process
-from avocado.plugins import plugin
 from avocado.virt import defaults
 
 try:

--- a/avocado/core/plugins/virt_bootstrap.py
+++ b/avocado/core/plugins/virt_bootstrap.py
@@ -15,9 +15,9 @@
 import os
 import urllib2
 
-from avocado.plugins import plugin
+from avocado import data_dir
 from avocado.core import output
-from avocado.core import data_dir
+from avocado.core.plugins import plugin
 from avocado.utils import download
 from avocado.utils import path
 from avocado.utils import crypto

--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -16,7 +16,7 @@
 Default values used in tests and plugin code.
 """
 
-from avocado.core import data_dir
+from avocado import data_dir
 from avocado.settings import settings
 from avocado.settings import SettingsError
 from avocado.virt.qemu import path

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 # pylint: disable=E0611
 from distutils.core import setup
 
-VERSION = '0.23.0'
+VERSION = '0.24.0'
 
 setup(name='avocado-virt',
       version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(name='avocado-virt',
                 'avocado.virt',
                 'avocado.virt.utils',
                 'avocado.virt.qemu',
-                'avocado.plugins'],
+                'avocado.core.plugins'],
       )


### PR DESCRIPTION
* avocado.plugins: Isolate avocado.plugins.virt* from being used by test developers.
* New upstream release 0.24.0.
* Add .gitignore from avocado project.