### PR TITLE
avocado.virt.qemu.machine: Explicitly pass 'default' param

### DIFF
--- a/avocado/virt/qemu/devices.py
+++ b/avocado/virt/qemu/devices.py
@@ -388,7 +388,7 @@ class QemuDevices(object):
         """
         if drive_file is None:
             drive_file = self.params.get('virt.guest.image_path',
-                                         defaults.guest_image_path)
+                                         default=defaults.guest_image_path)
         self.add_device('drive', drive_file=drive_file, device_type=device_type,
                         device_id=device_id, drive_id=drive_id)
 

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -132,7 +132,7 @@ class VM(object):
                 auto_close=False,
                 output_func=genio.log_line,
                 output_params=("serial-console-%s.log" % self.short_id,),
-                prompt=self.params.get("shell_prompt", "[\#\$]"))
+                prompt=self.params.get("shell_prompt", default="[\#\$]"))
             self._screendump_thread_start()
         finally:
             os.remove(self.monitor_socket)
@@ -246,7 +246,7 @@ class VM(object):
         clone.power_on()
         uri = "%s:localhost:%d" % (protocol, migration_port)
         self.qmp("migrate", uri=uri)
-        migrate_timeout = self.params.get('virt.qemu.migrate.timeout', defaults.migrate_timeout)
+        migrate_timeout = self.params.get('virt.qemu.migrate.timeout', default=defaults.migrate_timeout)
         migrate_result = wait.wait_for(migrate_complete, timeout=migrate_timeout,
                                        text='Waiting for migration to complete')
         if migrate_result is None:
@@ -277,10 +277,10 @@ class VM(object):
     def _screendump_thread_start(self):
         thread_enable = 'virt.screendumps.enable'
         self._screendump_thread_enable = self.params.get(thread_enable,
-                                                         defaults.screendump_thread_enable)
+                                                         default=defaults.screendump_thread_enable)
         video_enable = 'virt.videos.enable'
         self._video_enable = self.params.get(video_enable,
-                                             defaults.video_encoding_enable)
+                                             default=defaults.video_encoding_enable)
         if self._screendump_thread_enable:
             self.screendump_dir = utils_path.init_dir(
                 os.path.join(self.logdir, 'screendumps', self.short_id))
@@ -294,7 +294,7 @@ class VM(object):
         Take screendumps on regular intervals.
         """
         timeout = self.params.get('virt.screendumps.interval',
-                                  defaults.screendump_thread_interval)
+                                  default=defaults.screendump_thread_interval)
         dump_list = sorted(os.listdir(self.screendump_dir))
         if dump_list:
             last_dump = dump_list[-1].split('.')[0]

--- a/avocado/virt/utils/video.py
+++ b/avocado/virt/utils/video.py
@@ -74,7 +74,7 @@ class Encoder(object):
         """
         image_files = glob.glob(os.path.join(input_dir, '*.ppm'))
         quality = self.params.get('avocado.args.run.video_encoding.jpeg_quality',
-                                  defaults.video_encoding_jpeg_quality)
+                                  default=defaults.video_encoding_jpeg_quality)
         for ppm_file in image_files:
             ppm_file_basename = os.path.basename(ppm_file)
             jpg_file_basename = ppm_file_basename[:-4] + '.jpg'


### PR DESCRIPTION
Otherwise, params.get() will understand the default value
as the path, making the value returned incorrect (None).
Let's fix that.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>