### PR TITLE
Fix migration timeout

### DIFF
--- a/avocado-virt.spec
+++ b/avocado-virt.spec
@@ -1,7 +1,7 @@
 Summary: Avocado Virt Plugin
 Name: avocado-virt
 Version: 0.24.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
@@ -41,6 +41,9 @@ during avocado virt tests.
 %{python_sitelib}/avocado/virt/utils/video.py*
 
 %changelog
+* Fri May 22 2015 Lucas Meneghel Rodrigues <lmr@redhat.com> - 0.24.0-2
+- Fix issue with migration timeout settings
+
 * Mon May 18 2015 Ruda Moura <rmoura@redhat.com> - 0.24.0-1
 - New upstream release
 

--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -63,13 +63,13 @@ except SettingsError:
 guest_user = settings.get_value('virt.guest', 'user', default='root')
 guest_password = settings.get_value('virt.guest', 'password', default='123456')
 
-disable_restore_image_test = settings.get_value('virt.restore', 'disable_for_test', default=False)
-disable_restore_image_job = settings.get_value('virt.restore', 'disable_for_job', default=False)
+disable_restore_image_test = settings.get_value('virt.restore', 'disable_for_test', default=False, key_type=bool)
+disable_restore_image_job = settings.get_value('virt.restore', 'disable_for_job', default=False, key_type=bool)
 
-screendump_thread_enable = settings.get_value('virt.screendumps', 'enable', default=False)
-screendump_thread_interval = settings.get_value('virt.screendumps', 'interval', default=0.5)
+screendump_thread_enable = settings.get_value('virt.screendumps', 'enable', default=False, key_type=bool)
+screendump_thread_interval = settings.get_value('virt.screendumps', 'interval', default=0.5, key_type=float)
 
-video_encoding_enable = settings.get_value('virt.videos', 'enable', default=False)
+video_encoding_enable = settings.get_value('virt.videos', 'enable', default=False, key_type=bool)
 video_encoding_jpeg_quality = settings.get_value('virt.videos', 'jpeg_conversion_quality', default=95, key_type=int)
 
-migrate_timeout = settings.get_value('virt.qemu.migrate', 'timeout', default=60.0)
+migrate_timeout = settings.get_value('virt.qemu.migrate', 'timeout', default=60.0, key_type=float)

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -247,7 +247,7 @@ class VM(object):
         uri = "%s:localhost:%d" % (protocol, migration_port)
         self.qmp("migrate", uri=uri)
         migrate_timeout = self.params.get('virt.qemu.migrate.timeout', default=defaults.migrate_timeout)
-        migrate_result = wait.wait_for(migrate_complete, timeout=migrate_timeout,
+        migrate_result = wait.wait_for(migrate_complete, timeout=float(migrate_timeout),
                                        text='Waiting for migration to complete')
         if migrate_result is None:
             raise exceptions.TestFail("Migration of %s did not complete after %s s" %


### PR DESCRIPTION
A handful of changes with regards to settings handling in the avocado virt plugin, to avoid bugs while retrieving migration timeout values.