### PR TITLE
avocado-virt: Install virt.conf config file

### DIFF
--- a/avocado-virt.spec
+++ b/avocado-virt.spec
@@ -25,6 +25,9 @@ tests in avocado. Up to this point, QEMU/KVM is the only backend supported.
 
 %files
 %defattr(-,root,root,-)
+%dir /etc/avocado
+%dir /etc/avocado/conf.d
+%config(noreplace)/etc/avocado/conf.d/virt.conf
 %doc README.rst LICENSE
 %exclude %{python_sitelib}/avocado/virt/utils/video.py*
 %{python_sitelib}/avocado*

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,38 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import os
+
 # pylint: disable=E0611
 from distutils.core import setup
 
 VERSION = '0.24.0'
+
+VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
+
+def get_dir(system_path=None, virtual_path=None):
+    """
+    Retrieve VIRTUAL_ENV friendly path
+    :param system_path: Relative system path
+    :param virtual_path: Overrides system_path for virtual_env only
+    :return: VIRTUAL_ENV friendly path
+    """
+    if virtual_path is None:
+        virtual_path = system_path
+    if VIRTUAL_ENV:
+        if virtual_path is None:
+            virtual_path = []
+        return os.path.join(*virtual_path)
+    else:
+        if system_path is None:
+            system_path = []
+        return os.path.join(*(['/'] + system_path))
+
+
+def get_data_files():
+    data_files = [(get_dir(['etc', 'avocado', 'conf.d']),
+                   ['etc/avocado/conf.d/virt.conf'])]
+    return data_files
 
 setup(name='avocado-virt',
       version=VERSION,
@@ -28,4 +56,5 @@ setup(name='avocado-virt',
                 'avocado.virt.utils',
                 'avocado.virt.qemu',
                 'avocado.core.plugins'],
+      data_files=get_data_files()
       )


### PR DESCRIPTION
Turns out we forgot to include the configuration files
in the RPM install. Let's fix that.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>