### PR TITLE
Make avocado-virt work with the new AvocadoParams [v1]

### DIFF
--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -129,22 +129,18 @@ class VirtOptions(plugin.Plugin):
                   defaults.video_encoding_jpeg_quality)
 
         view = output.View(app_args=app_args)
-        if (hasattr(app_args, 'disable_restore_image_test') and
-                getattr(app_args, 'disable_restore_image_test')):
-            if (hasattr(app_args, 'disable_restore_image_job') and not
-                    getattr(app_args, 'disable_restore_image_job')):
-                if app_args.guest_image_path:
-                    drive_file = app_args.guest_image_path
-                else:
-                    drive_file = defaults.guest_image_path
-                compressed_drive_file = drive_file + '.7z'
-                if os.path.isfile(compressed_drive_file):
-                    if app_using_human_output(app_args):
-                        msg = ("Plugin setup (Restoring guest image backup). "
-                               "Please wait...")
-                        view.notify(event='minor', msg=msg)
-                    cwd = os.getcwd()
-                    os.chdir(os.path.dirname(compressed_drive_file))
-                    process.run('7za -y e %s' %
-                                os.path.basename(compressed_drive_file))
-                    os.chdir(cwd)
+        if (not defaults.disable_restore_image_job and
+                defaults.disable_restore_image_test):
+            # Don't restore the image when also restoring image per-test
+            drive_file = app_args.guest_image_path
+            compressed_drive_file = drive_file + '.7z'
+            if os.path.isfile(compressed_drive_file):
+                if app_using_human_output(app_args):
+                    msg = ("Plugin setup (Restoring guest image backup). "
+                           "Please wait...")
+                    view.notify(event='minor', msg=msg)
+                cwd = os.getcwd()
+                os.chdir(os.path.dirname(compressed_drive_file))
+                process.run('7za -y e %s' %
+                            os.path.basename(compressed_drive_file))
+                os.chdir(cwd)

--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -127,6 +127,8 @@ class VirtOptions(plugin.Plugin):
                   getattr(app_args, "record_videos", False))
         set_value('/plugins/virt/videos', 'jpeg_quality',
                   defaults.video_encoding_jpeg_quality)
+        set_value('/plugins/virt/guest', 'disable_restore_image_test',
+                  defaults.disable_restore_image_test)
 
         view = output.View(app_args=app_args)
         if (not defaults.disable_restore_image_job and

--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -102,24 +102,31 @@ class VirtOptions(plugin.Plugin):
                         return False
             return True
 
-        param = app_args.default_multiplex_tree.get_node('/run', True)
-        param.value['virt.qemu.paths.qemu_bin'] = app_args.qemu_bin
-        param.value['virt.qemu.paths.qemu_dst_bin'] = app_args.qemu_dst_bin
-        param.value['virt.qemu.paths.qemu_img_bin'] = app_args.qemu_img_bin
-        param.value['virt.qemu.paths.qemu_io_bin'] = app_args.qemu_io_bin
-        param.value['virt.guest.image_path'] = app_args.guest_image_path
-        param.value['virt.guest.user'] = app_args.guest_user
-        param.value['virt.guest.password'] = app_args.guest_password
-        param.value['virt.screendumps.enable'] = app_args.take_screendumps
-        param.value['virt.screendumps.interval'] = app_args.screendump_thread_interval
-        param.value['virt.qemu.migrate.timeout'] =  defaults.migrate_timeout
+        def set_value(path, key, value):
+            root.get_node(path, True).value[key] = value
+        root = app_args.default_multiplex_tree
+        set_value('/plugins/virt/qemu/paths', 'qemu_bin', app_args.qemu_bin)
+        set_value('/plugins/virt/qemu/paths', 'qemu_dst_bin',
+                  app_args.qemu_dst_bin)
+        set_value('/plugins/virt/qemu/paths', 'qemu_img_bin',
+                  app_args.qemu_img_bin)
+        set_value('/plugins/virt/paths', 'qemu_io_bin', app_args.qemu_io_bin)
+        set_value('/plugins/virt/guest', 'image_path', app_args.guest_image_path)
+        set_value('/plugins/virt/guest', 'user', app_args.guest_user)
+        set_value('/plugins/virt/guest', 'password', app_args.guest_password)
+        set_value('/plugins/virt/screendumps', 'enable',
+                  app_args.take_screendumps)
+        set_value('/plugins/virt/screendumps', 'interval',
+                  defaults.screendump_thread_interval)
+        set_value('/plugins/virt/qemu/migrate', 'timeout',
+                  defaults.migrate_timeout)
         if app_args.qemu_template:
-            template = app_args.qemu_template.read()
-            param.value['virt.qemu.template.contents'] = template
-        param.value["virt.videos.enable"] = getattr(app_args, "record_videos",
-                                                   False)
-        param.value['virt.videos.jpeg_quality'] = defaults.video_encoding_jpeg_quality
-        param.value['virt.restore.disable_for_test'] = not defaults.disable_restore_image_test
+            set_value('/plugins/virt/qemu/template', 'contents',
+                      app_args.qemu_template.read())
+        set_value('/plugins/virt/videos', 'enable',
+                  getattr(app_args, "record_videos", False))
+        set_value('/plugins/virt/videos', 'jpeg_quality',
+                  defaults.video_encoding_jpeg_quality)
 
         view = output.View(app_args=app_args)
         if (hasattr(app_args, 'disable_restore_image_test') and

--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -45,24 +45,24 @@ class VirtOptions(plugin.Plugin):
         virt_parser = parser.runner.add_argument_group('virtualization '
                                                        'testing arguments')
         virt_parser.add_argument(
-            '--qemu-bin', type=str,
+            '--qemu-bin', type=str, default=defaults.qemu_bin,
             help=('Path to a custom qemu binary to be tested. Current path: %s'
                   % defaults.qemu_bin))
         virt_parser.add_argument(
-            '--qemu-dst-bin', type=str,
+            '--qemu-dst-bin', type=str, default=defaults.qemu_dst,
             help=('Path to a destination qemu binary to be tested. Used as '
                   'incoming qemu in migration tests. Current path: %s'
                   % defaults.qemu_dst))
         virt_parser.add_argument(
-            '--qemu-img-bin', type=str,
+            '--qemu-img-bin', type=str, default=defaults.qemu_img_bin,
             help=('Path to a custom qemu-img binary to be tested. '
                   'Current path: %s' % defaults.qemu_img_bin))
         virt_parser.add_argument(
-            '--qemu-io-bin', type=str,
+            '--qemu-io-bin', type=str, default=defaults.qemu_io_bin,
             help=('Path to a custom qemu-io binary to be tested. '
                   'Current path: %s' % defaults.qemu_io_bin))
         virt_parser.add_argument(
-            '--guest-image-path', type=str,
+            '--guest-image-path', type=str, default=defaults.guest_image_path,
             help=('Path to a guest image to be used in tests. '
                   'Current path: %s' % defaults.guest_image_path))
         virt_parser.add_argument(
@@ -101,6 +101,25 @@ class VirtOptions(plugin.Plugin):
                     if app_args.__dict__[key] == '-':
                         return False
             return True
+
+        param = app_args.default_multiplex_tree.get_node('/run', True)
+        param.value['virt.qemu.paths.qemu_bin'] = app_args.qemu_bin
+        param.value['virt.qemu.paths.qemu_dst_bin'] = app_args.qemu_dst_bin
+        param.value['virt.qemu.paths.qemu_img_bin'] = app_args.qemu_img_bin
+        param.value['virt.qemu.paths.qemu_io_bin'] = app_args.qemu_io_bin
+        param.value['virt.guest.image_path'] = app_args.guest_image_path
+        param.value['virt.guest.user'] = app_args.guest_user
+        param.value['virt.guest.password'] = app_args.guest_password
+        param.value['virt.screendumps.enable'] = app_args.take_screendumps
+        param.value['virt.screendumps.interval'] = app_args.screendump_thread_interval
+        param.value['virt.qemu.migrate.timeout'] =  defaults.migrate_timeout
+        if app_args.qemu_template:
+            template = app_args.qemu_template.read()
+            param.value['virt.qemu.template.contents'] = template
+        param.value["virt.videos.enable"] = getattr(app_args, "record_videos",
+                                                   False)
+        param.value['virt.videos.jpeg_quality'] = defaults.video_encoding_jpeg_quality
+        param.value['virt.restore.disable_for_test'] = not defaults.disable_restore_image_test
 
         view = output.View(app_args=app_args)
         if (hasattr(app_args, 'disable_restore_image_test') and

--- a/avocado/virt/qemu/devices.py
+++ b/avocado/virt/qemu/devices.py
@@ -20,7 +20,6 @@
 
 from avocado.utils import network
 from avocado.utils.data_structures import Borg
-from avocado.virt import defaults
 from avocado.virt.qemu import path
 
 

--- a/avocado/virt/qemu/devices.py
+++ b/avocado/virt/qemu/devices.py
@@ -387,8 +387,7 @@ class QemuDevices(object):
         :param drive_id: String identifying the newly added drive.
         """
         if drive_file is None:
-            drive_file = self.params.get('virt.guest.image_path',
-                                         default=defaults.guest_image_path)
+            drive_file = self.params.get('image_path', '/plugins/virt/guest/*')
         self.add_device('drive', drive_file=drive_file, device_type=device_type,
                         device_id=device_id, drive_id=drive_id)
 

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -115,7 +115,7 @@ class VM(object):
         self.serial_socket = tempfile.mktemp()
         self.devices.add_serial(self.serial_socket)
 
-        tmpl = self.params.get('virt.qemu.template.contents')
+        tmpl = self.params.get('contents', '/plugins/virt/qemu/template/*')
 
         if tmpl is None:
             cmdline = self.devices.get_cmdline()
@@ -199,9 +199,9 @@ class VM(object):
             if hostname is None:
                 hostname = socket.gethostbyname(socket.gethostname())
             if username is None:
-                username = self.params.get('virt.guest.user')
+                username = self.params.get('user', '/plugins/virt/guest/*')
             if password is None:
-                password = self.params.get('virt.guest.password')
+                password = self.params.get('password', '/plugins/virt/guest/*')
             if port is None:
                 port = self.devices.ports.redir_port
             self.log('Login (Remote) -> '
@@ -246,7 +246,8 @@ class VM(object):
         clone.power_on()
         uri = "%s:localhost:%d" % (protocol, migration_port)
         self.qmp("migrate", uri=uri)
-        migrate_timeout = self.params.get('virt.qemu.migrate.timeout', default=defaults.migrate_timeout)
+        migrate_timeout = self.params.get('timeout',
+                                          '/plugins/virt/qemu/migrate/*')
         migrate_result = wait.wait_for(migrate_complete, timeout=float(migrate_timeout),
                                        text='Waiting for migration to complete')
         if migrate_result is None:
@@ -275,12 +276,11 @@ class VM(object):
         self.qmp(cmd='screendump', verbose=verbose, filename=filename)
 
     def _screendump_thread_start(self):
-        thread_enable = 'virt.screendumps.enable'
-        self._screendump_thread_enable = self.params.get(thread_enable,
-                                                         default=defaults.screendump_thread_enable)
+        self._screendump_thread_enable = self.params.get('enable',
+                                                         '/plugins/virt/screendumps/*')
         video_enable = 'virt.videos.enable'
-        self._video_enable = self.params.get(video_enable,
-                                             default=defaults.video_encoding_enable)
+        self._video_enable = self.params.get('enable',
+                                             '/plugins/virt/videos/*')
         if self._screendump_thread_enable:
             self.screendump_dir = utils_path.init_dir(
                 os.path.join(self.logdir, 'screendumps', self.short_id))
@@ -293,8 +293,7 @@ class VM(object):
         """
         Take screendumps on regular intervals.
         """
-        timeout = self.params.get('virt.screendumps.interval',
-                                  default=defaults.screendump_thread_interval)
+        timeout = self.params.get('interval', '/plugins/virt/screendumps/*')
         dump_list = sorted(os.listdir(self.screendump_dir))
         if dump_list:
             last_dump = dump_list[-1].split('.')[0]

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -30,7 +30,6 @@ from avocado.utils import remote
 from avocado.utils import wait
 from avocado.utils import path as utils_path
 
-from avocado.virt import defaults
 from avocado.virt.qemu import monitor
 from avocado.virt.qemu import devices
 from avocado.virt.qemu import path

--- a/avocado/virt/qemu/path.py
+++ b/avocado/virt/qemu/path.py
@@ -50,9 +50,9 @@ def get_qemu_binary(params=None):
     then, if nothing found, look in the system $PATH.
     """
     if params is not None:
-        params_qemu = params.get('virt.qemu.paths.qemu_bin')
+        params_qemu = params.get('qemu_bin', '/plugins/virt/qemu/paths/*')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_bin')
+            return _validate_path(params_qemu, 'qemu_bin from /plugins/virt/qemu/paths/*')
 
     env_qemu = os.environ.get('QEMU')
     if env_qemu is not None:
@@ -74,9 +74,9 @@ def get_qemu_dst_binary(params=None):
     This is for use in migration tests.
     """
     if params is not None:
-        params_qemu = params.get('virt.qemu.paths.qemu_dst_bin')
+        params_qemu = params.get('qemu_bin_dst', '/plugins/virt/qemu/paths/*')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_dst_bin')
+            return _validate_path(params_qemu, 'qemu_bin_dst from /plugins/virt/qemu/paths/*')
 
     env_qemu = os.environ.get('QEMU_DST')
     if env_qemu is not None:
@@ -93,9 +93,9 @@ def get_qemu_dst_binary(params=None):
 
 def get_qemu_img_binary(params=None):
     if params is not None:
-        params_qemu = params.get('virt.qemu.paths.qemu_img_bin')
+        params_qemu = params.get('qemu_img_bin', '/plugins/virt/qemu/paths/*')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_img_bin')
+            return _validate_path(params_qemu, 'qemu_img_bin from /plugins/virt/qemu/paths/*')
 
     env_qemu = os.environ.get('QEMU_IMG')
     if env_qemu is not None:
@@ -111,9 +111,9 @@ def get_qemu_img_binary(params=None):
 
 def get_qemu_io_binary(params=None):
     if params is not None:
-        params_qemu = params.get('virt.qemu.paths.qemu_io_bin')
+        params_qemu = params.get('qemu_io_bin', '/plugins/virt/qemu/paths/*')
         if params_qemu is not None:
-            return _validate_path(params_qemu, 'config value virt.qemu.paths.qemu_io_bin')
+            return _validate_path(params_qemu, 'qemu_io_bin from /plugins/virt/qemu/paths/*')
 
     env_qemu = os.environ.get('QEMU_IO')
     if env_qemu is not None:

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -34,10 +34,7 @@ class VirtTest(test.Test):
         """
         Restore any guest images defined in the command line.
         """
-        if self.params.get('virt.guest.image_path') is None:
-            drive_file = defaults.guest_image_path
-        else:
-            drive_file = self.params.get('virt.guest.image_path')
+        drive_file = self.params.get('image_path', '/plugins/virt/guest/*')
         # Check if there's a compressed drive file
         compressed_drive_file = drive_file + '.7z'
         if os.path.isfile(compressed_drive_file):

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -16,7 +16,6 @@
 import os
 from avocado import test
 from avocado.utils import process
-from avocado.virt import defaults
 from avocado.virt.qemu import machine
 
 
@@ -59,7 +58,8 @@ class VirtTest(test.Test):
         If only the test level restore is disabled, execute one restore (job).
         If both are disabled, then never restore.
         """
-        if not defaults.disable_restore_image_test:
+        if not self.params.get('disable_restore_image_test',
+                               '/plugins/virt/guest/*'):
             self._restore_guest_images()
         self.vm = machine.VM(params=self.params, logdir=self.logdir)
         self.vm.devices.add_nodefaults()

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -24,72 +24,11 @@ class VirtTest(test.Test):
 
     def __init__(self, methodName='runTest', name=None, params=None,
                  base_logdir=None, tag=None, job=None, runner_queue=None):
-        self.vm = None
-
-        if job is not None:
-            if job.args.qemu_bin:
-                params['virt.qemu.paths.qemu_bin'] = job.args.qemu_bin
-            else:
-                params['virt.qemu.paths.qemu_bin'] = defaults.qemu_bin
-
-            if job.args.qemu_dst_bin:
-                params['virt.qemu.paths.qemu_dst_bin'] = job.args.qemu_dst_bin
-            else:
-                params['virt.qemu.paths.qemu_dst_bin'] = defaults.qemu_dst
-
-            if job.args.qemu_img_bin:
-                params['virt.qemu.paths.qemu_img_bin'] = job.args.qemu_img_bin
-            else:
-                params['virt.qemu.paths.qemu_img_bin'] = defaults.qemu_img_bin
-
-            if job.args.qemu_io_bin:
-                params['virt.qemu.paths.qemu_io_bin'] = job.args.qemu_io_bin
-            else:
-                params['virt.qemu.paths.qemu_io_bin'] = defaults.qemu_io_bin
-
-            if job.args.guest_image_path:
-                params['virt.guest.image_path'] = job.args.guest_image_path
-            else:
-                params['virt.guest.image_path'] = defaults.guest_image_path
-
-            if job.args.guest_user:
-                params['virt.guest.user'] = job.args.guest_user
-            else:
-                params['virt.guest.user'] = defaults.guest_user
-
-            if job.args.guest_password:
-                params['virt.guest.password'] = job.args.guest_password
-            else:
-                params['virt.guest.password'] = defaults.guest_password
-
-            if job.args.take_screendumps:
-                params['virt.screendumps.enable'] = job.args.take_screendumps
-            else:
-                params['virt.screendumps.enable'] = defaults.screendump_thread_enable
-
-            params['virt.screendumps.interval'] = defaults.screendump_thread_interval
-
-            params['virt.qemu.migrate.timeout'] = defaults.migrate_timeout
-
-            if job.args.qemu_template:
-                params['virt.qemu.template.contents'] = \
-                    job.args.qemu_template.read()
-
-            if hasattr(job.args, 'record_videos'):
-                if getattr(job.args, 'record_videos'):
-                    params['virt.videos.enable'] = getattr(job.args, 'record_videos')
-            else:
-                params['virt.videos.enable'] = defaults.video_encoding_enable
-
-            params['virt.videos.jpeg_quality'] = defaults.video_encoding_jpeg_quality
-
-            params['virt.restore.disable_for_test'] = not \
-                defaults.disable_restore_image_test
-
         super(VirtTest, self).__init__(methodName=methodName, name=name,
                                        params=params, base_logdir=base_logdir,
                                        tag=tag, job=job,
                                        runner_queue=runner_queue)
+        self.vm = None
 
     def _restore_guest_images(self):
         """

--- a/avocado/virt/utils/video.py
+++ b/avocado/virt/utils/video.py
@@ -73,8 +73,7 @@ class Encoder(object):
         :param input_dir: Directory to inspect.
         """
         image_files = glob.glob(os.path.join(input_dir, '*.ppm'))
-        quality = self.params.get('avocado.args.run.video_encoding.jpeg_quality',
-                                  default=defaults.video_encoding_jpeg_quality)
+        quality = self.params.get('jpeg_quality', '/plugins/virt/videos/*')
         for ppm_file in image_files:
             ppm_file_basename = os.path.basename(ppm_file)
             jpg_file_basename = ppm_file_basename[:-4] + '.jpg'

--- a/avocado/virt/utils/video.py
+++ b/avocado/virt/utils/video.py
@@ -34,8 +34,6 @@ import gi
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst
 
-from avocado.virt import defaults
-
 log = logging.getLogger("avocado.test")
 
 


### PR DESCRIPTION
This patchset changes the way params are overridden from cmdline. Additionally it changes the flat names and uses key+path instead. See the descriptions for details.