### PR TITLE
API review: sync with the avocado API changes

### DIFF
--- a/avocado/core/plugins/virt_bootstrap.py
+++ b/avocado/core/plugins/virt_bootstrap.py
@@ -15,7 +15,7 @@
 import os
 import urllib2
 
-from avocado import data_dir
+from avocado.core import data_dir
 from avocado.core import output
 from avocado.core.plugins import plugin
 from avocado.utils import download

--- a/avocado/virt/defaults.py
+++ b/avocado/virt/defaults.py
@@ -16,9 +16,9 @@
 Default values used in tests and plugin code.
 """
 
-from avocado import data_dir
-from avocado.settings import settings
-from avocado.settings import SettingsError
+from avocado.core import data_dir
+from avocado.core.settings import settings
+from avocado.core.settings import SettingsError
 from avocado.virt.qemu import path
 
 try:

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -23,7 +23,7 @@ import threading
 import copy
 
 from avocado.core import exceptions
-from avocado import aexpect
+from avocado.core import aexpect
 from avocado.utils import genio
 from avocado.utils import process
 from avocado.utils import remote

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -14,13 +14,13 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 import os
-from avocado import test
+from avocado import Test
 from avocado.utils import process
 from avocado.virt import defaults
 from avocado.virt.qemu import machine
 
 
-class VirtTest(test.Test):
+class VirtTest(Test):
 
     def __init__(self, methodName='runTest', name=None, params=None,
                  base_logdir=None, tag=None, job=None, runner_queue=None):


### PR DESCRIPTION
While modules living under avocado.core are not intended to be
used by tests, at this point extensions are OK using it. We may,
in the (far?) future, come with an extension/plugin API definition
but this is currently out of scope.

So, for now, let's sync avocado-virt with the proposed changes on
avocado itself.

These are the changes that impact avocado-virt:

* rename of avocado.test.Test to avocado.Test
* rename of avocado.aexpect to avocado.core.aexpect
* rename of avocado.data_dir to avocado.core.data_dir
* rename of avocado.settings to avocado.core.settings

This is related to https://github.com/avocado-framework/avocado/pull/636 and was tested functionally on top of https://github.com/avocado-framework/avocado-virt/pull/54. 

Signed-off-by: Cleber Rosa <crosa@redhat.com>