### PR TITLE
plugins.virt: Remove the hack for not-modifying-multiplex

### DIFF
--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -98,12 +98,8 @@ class VirtOptions(plugin.Plugin):
         def set_value(path, key, arg=None, value=None):
             if arg:
                 value = getattr(app_args, arg, value)
-                root.get_node(path, True).value[key] = value
-            if value:
-                root.get_node(path, True).value[key] = value
+            root.get_node(path, True).value[key] = value
 
-        if not hasattr(app_args, 'qemu_bin'):   # Dummy run (avocado plugins)
-            return
         root = app_args.default_multiplex_tree
         set_value('/plugins/virt/qemu/paths', 'qemu_bin', arg='qemu_bin')
         set_value('/plugins/virt/qemu/paths', 'qemu_dst_bin', arg='qemu_dst_bin')


### PR DESCRIPTION
"avocado multiplex" was fixed and there is no need for the hack which
disabled the multiplex-tree injection when not running test.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>