### PR TITLE
avocado-virt: Change aexpect dependency

### DIFF
--- a/avocado-virt.spec
+++ b/avocado-virt.spec
@@ -8,7 +8,7 @@ URL: http://avocado-framework.readthedocs.org/
 Source: avocado-virt-%{version}.tar.gz
 BuildRequires: python2-devel
 BuildArch: noarch
-Requires: python, avocado
+Requires: python, avocado, aexpect
 
 %description
 Avocado Virt is a plugin that allows users to run virtualization related

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -22,8 +22,9 @@ import uuid as uuid_lib
 import threading
 import copy
 
+import aexpect
+
 from avocado.core import exceptions
-from avocado.core import aexpect
 from avocado.core import remoter
 from avocado.utils import genio
 from avocado.utils import process

--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ Package: avocado-virt
 Architecture: all
 Homepage: https://github.com/avocado-framework/avocado-virt
 XB-Python-Version: ${python:Versions}
-Depends: ${misc:Depends}, ${python:Depends}, avocado
+Depends: ${misc:Depends}, ${python:Depends}, avocado, aexpect
 Description: Avocado virtualization plugin.

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,3 @@
 pep8==1.6.2
 inspektor==0.1.15
+aexpect==1.0.0


### PR DESCRIPTION
Instead of using the avocado copy (that is going to
be removed), use the system wide copy (aexpect now
can be installed through RPMs and pip).

Changes from v1:
* Updated the `avocado-virt.spec` and `debian/control` files per @ldoktor's comments.