### PR TITLE
avocado-virt: Mass import cleanup

### DIFF
--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -17,7 +17,6 @@ Virtualization testing plugin.
 """
 
 import os
-
 from argparse import FileType
 
 from avocado.core import output

--- a/avocado/virt/qemu/machine.py
+++ b/avocado/virt/qemu/machine.py
@@ -30,11 +30,10 @@ from avocado.utils import genio
 from avocado.utils import process
 from avocado.utils import wait
 from avocado.utils import path as utils_path
-
 from avocado.virt.qemu import monitor
 from avocado.virt.qemu import devices
-from avocado.virt.qemu import path
 from avocado.virt.utils import image
+
 try:
     from avocado.virt.utils import video
     VIDEO_ENCODING_SUPPORT = True

--- a/avocado/virt/test.py
+++ b/avocado/virt/test.py
@@ -14,6 +14,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 import os
+
 from avocado import Test
 from avocado.utils import process
 from avocado.virt.qemu import machine

--- a/avocado/virt/utils/video.py
+++ b/avocado/virt/utils/video.py
@@ -28,9 +28,10 @@ import glob
 import os
 import re
 import logging
-from PIL import Image
 
+from PIL import Image
 import gi
+
 gi.require_version('Gst', '1.0')
 from gi.repository import Gst
 


### PR DESCRIPTION
This is an automated mass import cleanup across all
avocado-virt source files:

1) Imports follow the order:
 * Standard library imports
 * Non standard library external imports
 * Internal imports
 All separated by a single line
2) One line between imports and the rest of the code
3) Remove unused imports in the process

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>