### PR TITLE
requirements-travis.txt: Require inspektor 0.2.0

### DIFF
--- a/avocado/core/plugins/virt.py
+++ b/avocado/core/plugins/virt.py
@@ -26,8 +26,10 @@ from avocado.virt import defaults
 
 try:
     from avocado.virt.utils import video
+    # We are not going to need this module for now
+    del video
     VIDEO_ENCODING_SUPPORT = True
-except:
+except ImportError:
     VIDEO_ENCODING_SUPPORT = False
 
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,3 +1,3 @@
 pep8==1.6.2
-inspektor==0.1.16
+inspektor==0.2.0
 aexpect==1.0.0


### PR DESCRIPTION
This new version should know which pylint/astroid
combination to use on py 2.6.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>