### PR TITLE
Makefile: Add "python setup.py develop --user" to the "link" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ clean:
 
 link:
 	ln -sf ../../../../$(DIRNAME)/etc/avocado/conf.d/virt.conf ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/
+	$(PYTHON) setup.py develop --user
 
 unlink:
+	$(PYTHON) setup.py develop --uninstall --user
 	test -L ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/virt.conf && rm -f ../$(AVOCADO_DIRNAME)/etc/avocado/conf.d/virt.conf || true


### PR DESCRIPTION
With the recent change in avocado, the link/unlink targets should also
call "python setup.py develop --user" (--uninstall) to enable/disable
egg links.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>