### PR TITLE
avocado_virt: Stop using the removed "View" for logging

### DIFF
--- a/avocado_virt/plugins/virt.py
+++ b/avocado_virt/plugins/virt.py
@@ -16,10 +16,10 @@
 Virtualization testing plugin.
 """
 
+import logging
 import os
 from argparse import FileType
 
-from avocado.core import output
 from avocado.utils import process
 from avocado.plugins.base import CLI
 from .. import defaults
@@ -31,6 +31,9 @@ try:
     VIDEO_ENCODING_SUPPORT = True
 except ImportError:
     VIDEO_ENCODING_SUPPORT = False
+
+
+LOG = logging.getLogger("avocado.app")
 
 
 class VirtRun(CLI):
@@ -135,7 +138,6 @@ class VirtRun(CLI):
             return True
         self.__add_default_values(args)
 
-        view = output.View(app_args=args)
         if (not defaults.disable_restore_image_job and
                 defaults.disable_restore_image_test):
             # Don't restore the image when also restoring image per-test
@@ -143,9 +145,8 @@ class VirtRun(CLI):
             compressed_drive_file = drive_file + '.7z'
             if os.path.isfile(compressed_drive_file):
                 if app_using_human_output(args):
-                    msg = ("Plugin setup (Restoring guest image backup). "
-                           "Please wait...")
-                    view.notify(event='minor', msg=msg)
+                    LOG.debug("Plugin setup (Restoring guest image backup). "
+                              "Please wait...")
                 cwd = os.getcwd()
                 os.chdir(os.path.dirname(compressed_drive_file))
                 process.run('7za -y e %s' %

--- a/avocado_virt/plugins/virt_bootstrap.py
+++ b/avocado_virt/plugins/virt_bootstrap.py
@@ -12,17 +12,20 @@
 # Copyright: Red Hat Inc. 2013-2014
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
+import logging
 import os
 import urllib2
 
 from avocado.core import data_dir
-from avocado.core import output
 from avocado.utils import download
 from avocado.utils import path
 from avocado.utils import crypto
 from avocado.utils import process
 from avocado.utils import path as utils_path
 from avocado.plugins.base import CLICmd
+
+
+LOG = logging.getLogger("avocado.app")
 
 
 class VirtBootstrap(CLICmd):
@@ -36,30 +39,24 @@ class VirtBootstrap(CLICmd):
 
     def run(self, args):
         fail = False
-        view = output.View(app_args=args)
-        view.notify(event='message', msg='Probing your system for test requirements')
+        LOG.info('Probing your system for test requirements')
         try:
             utils_path.find_command('7za')
-            view.notify(event='minor', msg='7zip present')
+            logging.debug('7zip present')
         except utils_path.CmdNotFoundError:
-            view.notify(event='warning',
-                        msg=("7za not installed. You may "
-                             "install 'p7zip' (or the "
-                             "equivalent on your distro) to "
-                             "fix the problem"))
+            LOG.warn("7za not installed. You may install 'p7zip' (or the "
+                     "equivalent on your distro) to fix the problem")
             fail = True
 
         jeos_sha1_url = 'http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS21'
         try:
-            view.notify(event='minor',
-                        msg=('Verifying expected SHA1 '
-                             'sum from %s' % jeos_sha1_url))
+            LOG.debug('Verifying expected SHA1 sum from %s', jeos_sha1_url)
             sha1_file = urllib2.urlopen(jeos_sha1_url)
             sha1_contents = sha1_file.read()
             sha1 = sha1_contents.split(" ")[0]
-            view.notify(event='minor', msg='Expected SHA1 sum: %s' % sha1)
-        except Exception, e:
-            view.notify(event='error', msg='Failed to get SHA1 from file: %s' % e)
+            LOG.debug('Expected SHA1 sum: %s', sha1)
+        except Exception, exc:
+            LOG.error('Failed to get SHA1 from file: %s', exc)
             fail = True
 
         jeos_dst_dir = path.init_dir(os.path.join(data_dir.get_data_dir(),
@@ -74,46 +71,36 @@ class VirtBootstrap(CLICmd):
 
         if actual_sha1 != sha1:
             if actual_sha1 == '0':
-                view.notify(event='minor',
-                            msg=('JeOS could not be found at %s. Downloading '
-                                 'it (192 MB). Please wait...' % jeos_dst_path))
+                LOG.debug('JeOS could not be found at %s. Downloading '
+                          'it (192 MB). Please wait...', jeos_dst_path)
             else:
-                view.notify(event='minor',
-                            msg=('JeOS at %s is either corrupted or outdated. '
-                                 'Downloading a new copy (192 MB). '
-                                 'Please wait...' % jeos_dst_path))
+                LOG.debug('JeOS at %s is either corrupted or outdated. '
+                          'Downloading a new copy (192 MB). '
+                          'Please wait...', jeos_dst_path)
             jeos_url = 'http://assets-avocadoproject.rhcloud.com/static/jeos-21-64.qcow2.7z'
             try:
                 download.url_download(jeos_url, jeos_dst_path)
             except:
-                view.notify(event='warning',
-                            msg=('Exiting upon user request (Download '
-                                 'not finished)'))
+                LOG.warn('Exiting upon user request (Download not finished)')
         else:
-            view.notify(event='minor',
-                        msg=('Compressed JeOS image found '
-                             'in %s, with proper SHA1' % jeos_dst_path))
+            LOG.debug('Compressed JeOS image found in %s, with proper SHA1',
+                      jeos_dst_path)
 
-        view.notify(event='minor',
-                    msg=('Uncompressing the JeOS image to restore pristine '
-                         'state. Please wait...'))
+        LOG.debug('Uncompressing the JeOS image to restore pristine '
+                  'state. Please wait...')
         os.chdir(os.path.dirname(jeos_dst_path))
         result = process.run('7za -y e %s' % os.path.basename(jeos_dst_path),
                              ignore_status=True)
         if result.exit_status != 0:
-            view.notify(event='error',
-                        msg=('Error uncompressing the image '
-                             '(see details below):\n%s' % result))
+            LOG.error('Error uncompressing the image (see details below):\n%s',
+                      result)
             fail = True
         else:
-            view.notify(event='minor', msg='Successfully uncompressed the image')
+            LOG.debug('Successfully uncompressed the image')
 
         if fail:
-            view.notify(event='warning',
-                        msg=('Problems found probing this system for tests '
-                             'requirements. Please check the error messages '
-                             'and fix the problems found'))
+            LOG.warn('Problems found probing this system for tests '
+                     'requirements. Please check the error messages '
+                     'and fix the problems found')
         else:
-            view.notify(event='message',
-                        msg=('Your system appears to be all '
-                             'set to execute tests'))
+            LOG.info('Your system appears to be all set to execute tests')


### PR DESCRIPTION
This patch adjusts the code to work with the new non-View logging
approach.

This needs to be merged together with https://github.com/avocado-framework/avocado/pull/1040