### PR TITLE
SPEC file: require avocado package of the same version

### DIFF
--- a/avocado-virt.spec
+++ b/avocado-virt.spec
@@ -7,14 +7,15 @@
 Summary: Avocado Virt Plugin
 Name: avocado-virt
 Version: 0.33.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: http://avocado-framework.readthedocs.org/
 Source0: https://github.com/avocado-framework/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
 BuildRequires: python2-devel, python-setuptools
 BuildArch: noarch
-Requires: python, avocado, aexpect
+Requires: avocado == ${version}
+Requires: python, aexpect
 
 %description
 Avocado Virt is a plugin that allows users to run virtualization related
@@ -50,6 +51,9 @@ during avocado virt tests.
 %{python_sitelib}/avocado_virt/utils/video.py*
 
 %changelog
+* Tue Feb 23 2016 Cleber Rosa <cleber@redhat.com> - 0.33.0-1
+- Require the avocado package of the exact same version
+
 * Wed Feb 17 2016 Cleber Rosa <cleber@redhat.com> - 0.33.0-0
 - New upstream release 0.33.0
 


### PR DESCRIPTION
So far the RPM packages have not been strict about the version
of avocado that they require.  The same version has probably
been used because of newer package availability on the repos.

Anyway, let's require the same package versions so that users
may not be surprised with breakage because of different version
and interfaces.

Signed-off-by: Cleber Rosa <crosa@redhat.com>