### PR TITLE
avocado_virt.plugins: Rename the `args.default_multiplex_tree`

### DIFF
--- a/avocado_virt/plugins/virt.py
+++ b/avocado_virt/plugins/virt.py
@@ -103,7 +103,7 @@ class VirtRun(CLI):
                 value = getattr(app_args, arg, value)
             root.get_node(path, True).value[key] = value
 
-        root = app_args.default_multiplex_tree
+        root = app_args.default_avocado_params
         set_value('/plugins/virt/qemu/paths', 'qemu_bin', arg='qemu_bin')
         set_value('/plugins/virt/qemu/paths', 'qemu_dst_bin', arg='qemu_dst_bin')
         set_value('/plugins/virt/qemu/paths', 'qemu_img_bin', arg='qemu_img_bin')


### PR DESCRIPTION
The `args.default_multiplex_tree` is renamed to
`default_avocado_params` in `avocado`.

__This has to be merged together with https://github.com/avocado-framework/avocado/pull/1138 PR__