### PR TITLE
JeOS: update default image to JeOS 23

### DIFF
--- a/avocado_virt/defaults.py
+++ b/avocado_virt/defaults.py
@@ -58,7 +58,7 @@ try:
     guest_image_path = settings.get_value('virt.guest', 'image_path')
 except SettingsError:
     guest_image_path = data_dir.get_datafile_path('images',
-                                                  'jeos-21-64.qcow2')
+                                                  'jeos-23-64.qcow2')
 
 guest_user = settings.get_value('virt.guest', 'user', default='root')
 guest_password = settings.get_value('virt.guest', 'password', default='123456')

--- a/avocado_virt/plugins/virt_bootstrap.py
+++ b/avocado_virt/plugins/virt_bootstrap.py
@@ -48,7 +48,7 @@ class VirtBootstrap(CLICmd):
                      "equivalent on your distro) to fix the problem")
             fail = True
 
-        jeos_sha1_url = 'http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS21'
+        jeos_sha1_url = 'http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23'
         try:
             LOG.debug('Verifying expected SHA1 sum from %s', jeos_sha1_url)
             sha1_file = urllib2.urlopen(jeos_sha1_url)
@@ -61,7 +61,7 @@ class VirtBootstrap(CLICmd):
 
         jeos_dst_dir = path.init_dir(os.path.join(data_dir.get_data_dir(),
                                                   'images'))
-        jeos_dst_path = os.path.join(jeos_dst_dir, 'jeos-21-64.qcow2.7z')
+        jeos_dst_path = os.path.join(jeos_dst_dir, 'jeos-23-64.qcow2.7z')
 
         if os.path.isfile(jeos_dst_path):
             actual_sha1 = crypto.hash_file(filename=jeos_dst_path,
@@ -72,12 +72,12 @@ class VirtBootstrap(CLICmd):
         if actual_sha1 != sha1:
             if actual_sha1 == '0':
                 LOG.debug('JeOS could not be found at %s. Downloading '
-                          'it (192 MB). Please wait...', jeos_dst_path)
+                          'it (204 MB). Please wait...', jeos_dst_path)
             else:
                 LOG.debug('JeOS at %s is either corrupted or outdated. '
-                          'Downloading a new copy (192 MB). '
+                          'Downloading a new copy (204 MB). '
                           'Please wait...', jeos_dst_path)
-            jeos_url = 'http://assets-avocadoproject.rhcloud.com/static/jeos-21-64.qcow2.7z'
+            jeos_url = 'http://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.7z'
             try:
                 download.url_download(jeos_url, jeos_dst_path)
             except:

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -36,9 +36,9 @@ The output should be similar to::
 
     Probing your system for test requirements
     7zip present
-    Verifying expected SHA1 sum from http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS21
+    Verifying expected SHA1 sum from http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23
     Expected SHA1 sum: 177468b8e5fcb7b9c5982a6bc21ff45df6d80b2f
-    Compressed JeOS image found in /home/<user>/avocado/data/images/jeos-21-64.qcow2.7z, with proper SHA1
+    Compressed JeOS image found in /home/<user>/avocado/data/images/jeos-23-64.qcow2.7z, with proper SHA1
     Uncompressing the JeOS image to restore pristine state. Please wait...
     Successfully uncompressed the image
     Your system appears to be all set to execute tests
@@ -63,7 +63,7 @@ extra parameters that you can pass::
                             path: /bin/qemu-io
       --guest-image-path GUEST_IMAGE_PATH
                             Path to a guest image to be used in tests. Current
-                            path: /home/<user>/avocado/data/images/jeos-21-64.qcow2
+                            path: /home/<user>/avocado/data/images/jeos-23-64.qcow2
       --guest-user GUEST_USER
                             User that avocado should use for remote logins.
                             Current: root


### PR DESCRIPTION
The recent change on Avocado-VT makes JeOS 23 the default image.
Let's change it here accordingly.

Signed-off-by: Cleber Rosa <crosa@redhat.com>