### PR TITLE
avocado_virt: Fix remoter params

### DIFF
--- a/avocado_virt/qemu/machine.py
+++ b/avocado_virt/qemu/machine.py
@@ -208,8 +208,8 @@ class VM(object):
             self.log('Login (Remote) -> '
                      '(hostname=%s, username=%s, password=%s, port=%s)'
                      % (hostname, username, password, port))
-            self.remote = remoter.Remote(hostname, username, password, port,
-                                         timeout=timeout)
+            self.remote = remoter.Remote(hostname, username, password,
+                                         port=port, timeout=timeout)
             res = self.remote.uptime()
             if res.succeeded:
                 self.logged = True


### PR DESCRIPTION
The position of arguments in "avocado.core.remoter" changed which caused
the "port" being used as "pam_file" instead making all tests fail with
SystemExit from fabric. This patch uses "port=port" to avoid such
problems in the future.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>