### PR TITLE
RFC: Plugin interfaces: adjustments for changes in Avocado

### DIFF
--- a/avocado_virt/plugins/virt.py
+++ b/avocado_virt/plugins/virt.py
@@ -21,7 +21,14 @@ import os
 from argparse import FileType
 
 from avocado.utils import process
-from avocado.plugins.base import CLI
+
+# Avocado's plugin interface module has changed location. Let's keep
+# compatibility with old for at, least, a new LTS release
+try:
+    from avocado.core.plugin_interfaces import CLI
+except ImportError:
+    from avocado.plugins.base import CLI
+
 from .. import defaults
 
 try:

--- a/avocado_virt/plugins/virt_bootstrap.py
+++ b/avocado_virt/plugins/virt_bootstrap.py
@@ -22,7 +22,13 @@ from avocado.utils import path
 from avocado.utils import crypto
 from avocado.utils import process
 from avocado.utils import path as utils_path
-from avocado.plugins.base import CLICmd
+
+# Avocado's plugin interface module has changed location. Let's keep
+# compatibility with old for at, least, a new LTS release
+try:
+    from avocado.core.plugin_interfaces import CLICmd
+except ImportError:
+    from avocado.plugins.base import CLICmd
 
 
 LOG = logging.getLogger("avocado.app")


### PR DESCRIPTION
This adjusts, while keeping compatibility, with the proposed change
for a better module name and location for the plugin interface
definitions.

This is related to https://github.com/avocado-framework/avocado/pull/1235

Signed-off-by: Cleber Rosa <crosa@redhat.com>