### PR TITLE
doc: Improve doc regarding skipping the image restore [v2]

### DIFF
--- a/docs/source/GuestConfiguration.rst
+++ b/docs/source/GuestConfiguration.rst
@@ -10,9 +10,11 @@ compressed qcow2 image located on my image repository that is downloaded,
 should you choose to run the sub command ``virt-bootstrap``.
 
 If you use avocado with default settings, the test runner is going to uncompress
-the pristine image of this so-called JeOS before each test. You may provide both
---disable-restore-image-test and --disable-restore-image-job options if you want
-to completely skip the backup restore process.
+the pristine image of this so-called JeOS before each test. You might change
+this behavior in config ``virt.restore.disable_for_{test|job}``
+(``/etc/avocado/conf.d/virt.conf``) or via multiplexer params
+``disable_restore_image_{test|job}`` in ``/plugins/virt/guest/`` namespace if
+you want to completely skip the backup restore process.
 
 Or, you may opt for using your own guest image in your tests.
 


### PR DESCRIPTION
… yaml file.

The commit 8185537 removed restore image related cmdline options.
This patch removed related original descriptions in doc and indicates users how
add doc how to skip backup restore process via plugin config file or
to skip the backup restore process via plugin config file or yaml file.

v1: https://github.com/avocado-framework/avocado-virt/pull/81

Changes:

```yaml
v2: Use '``' around the terms
```