### PR TITLE
Don't raise exception on os.remove() during power_off()

### DIFF
--- a/avocado_virt/qemu/machine.py
+++ b/avocado_virt/qemu/machine.py
@@ -150,7 +150,10 @@ class VM(object):
             self._popen = None
             self.pid = None
             self.serial_console.close()
-            os.remove(self.serial_socket)
+            try:
+                os.remove(self.serial_socket)
+            except:
+                pass
 
     def __enter__(self):
         self.power_on()


### PR DESCRIPTION
Depending on the qemu version, the chardev is auto-removed on
vm poweroff. Let's not make the test to fail on os.remove exception.

Signed-off-by: Amador Pahim <apahim@redhat.com>