### PR TITLE
qemu: Use KVM if possible

### DIFF
--- a/avocado_virt/qemu/machine.py
+++ b/avocado_virt/qemu/machine.py
@@ -113,6 +113,11 @@ class VM(object):
                                                 server=True)
         self.serial_socket = tempfile.mktemp()
         self.devices.add_serial(self.serial_socket)
+        if os.access('/dev/kvm', os.W_OK):
+            self.log('Using KVM')
+            self.devices.add_cmdline("-enable-kvm")
+        else:
+            self.log('/dev/kvm not accessible, not using KVM')
 
         tmpl = self.params.get('contents', '/plugins/virt/qemu/template/*')
 


### PR DESCRIPTION
On Fedora 24, the boot test hangs for me. Adding -enable-kvm to the QEMU
command line fixes it. While I haven't digged into why it hangs with
TCG, adding -enable-kvm if possible is useful nevertheless.

Test the accessibility of /dev/kvm file, which is the universal entry to
KVM, and add -enable-kvm to the command line if available.

Also add a line of log once the decision is done.

Thanks to Amador Pahim <apahim@redhat.com> for the help on this patch.

Signed-off-by: Fam Zheng <famz@redhat.com>

---

This fixes issue #88.