### PR TITLE
Default to "copy image" instead of "restore to pristine"

### DIFF
--- a/avocado_virt/defaults.py
+++ b/avocado_virt/defaults.py
@@ -63,8 +63,8 @@ except SettingsError:
 guest_user = settings.get_value('virt.guest', 'user', default='root')
 guest_password = settings.get_value('virt.guest', 'password', default='123456')
 
-disable_restore_image_test = settings.get_value('virt.restore', 'disable_for_test', default=False, key_type=bool)
-disable_restore_image_job = settings.get_value('virt.restore', 'disable_for_job', default=False, key_type=bool)
+disable_restore_image_test = settings.get_value('virt.restore', 'disable_for_test', default=True, key_type=bool)
+disable_restore_image_job = settings.get_value('virt.restore', 'disable_for_job', default=True, key_type=bool)
 
 screendump_thread_enable = settings.get_value('virt.screendumps', 'enable', default=False, key_type=bool)
 screendump_thread_interval = settings.get_value('virt.screendumps', 'interval', default=0.5, key_type=float)

--- a/avocado_virt/qemu/devices.py
+++ b/avocado_virt/qemu/devices.py
@@ -18,6 +18,10 @@
 # Author: Stefan Hajnoczi <stefanha@redhat.com>
 # Author: Ruda Moura <rmoura@redhat.com>
 
+import os
+import shutil
+import tempfile
+from avocado.core import data_dir
 from avocado.utils import network
 from avocado.utils.data_structures import Borg
 from . import path
@@ -374,7 +378,8 @@ class QemuDevices(object):
         self.add_device('fd', fd=fd, fdset=fdset, opaque=opaque, opts=opts)
 
     def add_drive(self, drive_file=None, device_type='virtio-blk-pci',
-                  device_id='avocado_image', drive_id='device_avocado_image'):
+                  device_id='avocado_image', drive_id='device_avocado_image',
+                  copy=False):
         """
         Add a drive device to the VM.
 
@@ -387,6 +392,13 @@ class QemuDevices(object):
         """
         if drive_file is None:
             drive_file = self.params.get('image_path', '/plugins/virt/guest/*')
+        if copy:
+            basename = os.path.basename(drive_file)
+            dest = tempfile.mktemp(dir=data_dir.get_tmp_dir(),
+                                   suffix="-" + basename)
+            shutil.copy(drive_file, dest)
+            drive_file = dest
+
         self.add_device('drive', drive_file=drive_file, device_type=device_type,
                         device_id=device_id, drive_id=drive_id)
 

--- a/avocado_virt/test.py
+++ b/avocado_virt/test.py
@@ -65,5 +65,5 @@ class VirtTest(Test):
         self.vm.devices.add_nodefaults()
         self.vm.devices.add_vga('std')
         self.vm.devices.add_vnc()
-        self.vm.devices.add_drive()
+        self.vm.devices.add_drive(copy=True)
         self.vm.devices.add_net()

--- a/etc/avocado/conf.d/virt.conf
+++ b/etc/avocado/conf.d/virt.conf
@@ -8,9 +8,9 @@ password = 123456
 
 [virt.restore]
 # Disable restoring guest image during virt test jobs
-disable_for_job = False
+disable_for_job = True
 # Disable restoring guest image between every virt test
-disable_for_test = False
+disable_for_test = True
 
 [virt.screendumps]
 # Enable taking screendumps of vms during tests


### PR DESCRIPTION
Decompressing the 7z image takes 9 seconds, while copying the image to
temperory directory takes less than one, on my laptop with SSD. Even
with spindle disks, it's likely that copying is way faster, considering
the effect of page cache.

Add a parameter to add_drive to "copy" the image, and use it in VirtTest
default devices. With that, default restore to disable.

This makes a cycle for each test and job much shorter.

Signed-off-by: Fam Zheng famz@redhat.com
