### PR TITLE
avocado_virt: Adjust the code to cope with Remoter location change

### DIFF
--- a/avocado_virt/qemu/machine.py
+++ b/avocado_virt/qemu/machine.py
@@ -25,7 +25,6 @@ import copy
 import aexpect
 
 from avocado.core import exceptions
-from avocado.core import remoter
 from avocado.core import data_dir
 from avocado.utils import genio
 from avocado.utils import process
@@ -34,6 +33,12 @@ from avocado.utils import path as utils_path
 from . import monitor
 from . import devices
 from ..utils import image
+
+try:
+    from avocado_runner_remote import Remote
+except ImportError:
+    # Old location of the Remoter not available since avocado-46.0
+    from avocado.core.remoter import Remote
 
 try:
     from ..utils import video
@@ -215,8 +220,8 @@ class VM(object):
             self.log('Login (Remote) -> '
                      '(hostname=%s, username=%s, password=%s, port=%s)'
                      % (hostname, username, password, port))
-            self.remote = remoter.Remote(hostname, username, password,
-                                         port=port, timeout=timeout)
+            self.remote = Remote(hostname, username, password, port=port,
+                                 timeout=timeout)
             res = self.remote.uptime()
             if res.succeeded:
                 self.logged = True


### PR DESCRIPTION
The `avocado.core.remoter` had been moved to an optional plugin called
`avocado-runner-remote`. Let's adjust the code in order to work with the
latest avocado.

Currently this module is not shipped to pip so don't depend on it just
yet, but we'll have to add this requirement later.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>