### PR TITLE
JeOS: switch to JeOS version 25 and compression based on xz

### DIFF
--- a/avocado_virt/defaults.py
+++ b/avocado_virt/defaults.py
@@ -58,7 +58,7 @@ try:
     guest_image_path = settings.get_value('virt.guest', 'image_path')
 except SettingsError:
     guest_image_path = data_dir.get_datafile_path('images',
-                                                  'jeos-23-64.qcow2')
+                                                  'jeos-25-64.qcow2')
 
 guest_user = settings.get_value('virt.guest', 'user', default='root')
 guest_password = settings.get_value('virt.guest', 'password', default='123456')

--- a/avocado_virt/plugins/virt.py
+++ b/avocado_virt/plugins/virt.py
@@ -149,13 +149,13 @@ class VirtRun(CLI):
                 defaults.disable_restore_image_test):
             # Don't restore the image when also restoring image per-test
             drive_file = getattr(args, 'guest_image_path', None)
-            compressed_drive_file = drive_file + '.7z'
+            compressed_drive_file = drive_file + '.xz'
             if os.path.isfile(compressed_drive_file):
                 if app_using_human_output(args):
                     LOG.debug("Plugin setup (Restoring guest image backup). "
                               "Please wait...")
                 cwd = os.getcwd()
                 os.chdir(os.path.dirname(compressed_drive_file))
-                process.run('7za -y e %s' %
+                process.run('xz -d %s' %
                             os.path.basename(compressed_drive_file))
                 os.chdir(cwd)

--- a/avocado_virt/plugins/virt_bootstrap.py
+++ b/avocado_virt/plugins/virt_bootstrap.py
@@ -47,14 +47,14 @@ class VirtBootstrap(CLICmd):
         fail = False
         LOG.info('Probing your system for test requirements')
         try:
-            utils_path.find_command('7za')
-            logging.debug('7zip present')
+            utils_path.find_command('xz')
+            logging.debug('xz present')
         except utils_path.CmdNotFoundError:
-            LOG.warn("7za not installed. You may install 'p7zip' (or the "
+            LOG.warn("xz not installed. You may install xz (or the "
                      "equivalent on your distro) to fix the problem")
             fail = True
 
-        jeos_sha1_url = 'http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23'
+        jeos_sha1_url = 'http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS25'
         try:
             LOG.debug('Verifying expected SHA1 sum from %s', jeos_sha1_url)
             sha1_file = urllib2.urlopen(jeos_sha1_url)
@@ -67,7 +67,7 @@ class VirtBootstrap(CLICmd):
 
         jeos_dst_dir = path.init_dir(os.path.join(data_dir.get_data_dir(),
                                                   'images'))
-        jeos_dst_path = os.path.join(jeos_dst_dir, 'jeos-23-64.qcow2.7z')
+        jeos_dst_path = os.path.join(jeos_dst_dir, 'jeos-25-64.qcow2.xz')
 
         if os.path.isfile(jeos_dst_path):
             actual_sha1 = crypto.hash_file(filename=jeos_dst_path,
@@ -78,12 +78,12 @@ class VirtBootstrap(CLICmd):
         if actual_sha1 != sha1:
             if actual_sha1 == '0':
                 LOG.debug('JeOS could not be found at %s. Downloading '
-                          'it (204 MB). Please wait...', jeos_dst_path)
+                          'it (205 MB). Please wait...', jeos_dst_path)
             else:
                 LOG.debug('JeOS at %s is either corrupted or outdated. '
-                          'Downloading a new copy (204 MB). '
+                          'Downloading a new copy (205 MB). '
                           'Please wait...', jeos_dst_path)
-            jeos_url = 'http://assets-avocadoproject.rhcloud.com/static/jeos-23-64.qcow2.7z'
+            jeos_url = 'http://assets-avocadoproject.rhcloud.com/static/jeos-25-64.qcow2.xz'
             try:
                 download.url_download(jeos_url, jeos_dst_path)
             except:
@@ -95,7 +95,7 @@ class VirtBootstrap(CLICmd):
         LOG.debug('Uncompressing the JeOS image to restore pristine '
                   'state. Please wait...')
         os.chdir(os.path.dirname(jeos_dst_path))
-        result = process.run('7za -y e %s' % os.path.basename(jeos_dst_path),
+        result = process.run('xz -d %s' % os.path.basename(jeos_dst_path),
                              ignore_status=True)
         if result.exit_status != 0:
             LOG.error('Error uncompressing the image (see details below):\n%s',

--- a/avocado_virt/test.py
+++ b/avocado_virt/test.py
@@ -35,14 +35,14 @@ class VirtTest(Test):
         """
         drive_file = self.params.get('image_path', '/plugins/virt/guest/*')
         # Check if there's a compressed drive file
-        compressed_drive_file = drive_file + '.7z'
+        compressed_drive_file = drive_file + '.xz'
         if os.path.isfile(compressed_drive_file):
             self.log.debug('Found compressed image %s and restore guest '
                            'image set. Restoring image...',
                            compressed_drive_file)
             cwd = os.getcwd()
             os.chdir(os.path.dirname(compressed_drive_file))
-            process.run('7za -y e %s' %
+            process.run('xz -d %s' %
                         os.path.basename(compressed_drive_file))
             os.chdir(cwd)
         else:

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -38,10 +38,10 @@ command. Example::
 The output should be similar to::
 
     Probing your system for test requirements
-    7zip present
-    Verifying expected SHA1 sum from http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS23
-    Expected SHA1 sum: 177468b8e5fcb7b9c5982a6bc21ff45df6d80b2f
-    Compressed JeOS image found in /home/<user>/avocado/data/images/jeos-23-64.qcow2.7z, with proper SHA1
+    xz present
+    Verifying expected SHA1 sum from http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS25
+    Expected SHA1 sum: 7f5a440f6eb83577d42f9f68987534b1076967d8
+    Compressed JeOS image found in /home/<user>/avocado/data/images/jeos-25-64.qcow2.xz, with proper SHA1
     Uncompressing the JeOS image to restore pristine state. Please wait...
     Successfully uncompressed the image
     Your system appears to be all set to execute tests
@@ -66,7 +66,7 @@ extra parameters that you can pass::
                             path: /bin/qemu-io
       --guest-image-path GUEST_IMAGE_PATH
                             Path to a guest image to be used in tests. Current
-                            path: /home/<user>/avocado/data/images/jeos-23-64.qcow2
+                            path: /home/<user>/avocado/data/images/jeos-25-64.qcow2
       --guest-user GUEST_USER
                             User that avocado should use for remote logins.
                             Current: root


### PR DESCRIPTION
This syncs Avocado-Virt with the changes already present on
Avocado-VT: the image compression method is now xz, and the
default JeOS version is 25.

Signed-off-by: Cleber Rosa <crosa@redhat.com>