### PR TITLE
Reorganize and document defaults

### DIFF
--- a/avocado_virt/defaults.py
+++ b/avocado_virt/defaults.py
@@ -21,55 +21,93 @@ from avocado.core.settings import settings
 from avocado.core.settings import SettingsError
 from .qemu import path
 
+
+#: The name or path of the QEMU binary.  Hardcoded default is 'qemu',
+#: but will be overwritten by configuration value ("qemu_bin" under
+#: section [virt.qemu.paths]) or by a dynamic (run time) search for a
+#: suitable binary
+QEMU_BIN = 'qemu'
 try:
-    qemu_bin = settings.get_value('virt.qemu.paths', 'qemu_bin')
+    QEMU_BIN = settings.get_value('virt.qemu.paths', 'qemu_bin')
 except SettingsError:
     try:
-        qemu_bin = path.get_qemu_binary()
+        QEMU_BIN = path.get_qemu_binary()
     except path.QEMUCmdNotFoundError:
-        qemu_bin = 'qemu'
+        pass
 
+#: The name or path of the QEMU binary used for the destination
+#: instance when doing migration.  Hardcoded default is 'qemu', but
+#: will be overwritten by configuration value ("qemu_bin" under section
+#: [virt.qemu.paths]) or by a dynamic (run time) search for a suitable
+#: binary
+QEMU_DST_BIN = 'qemu'
 try:
-    qemu_dst = settings.get_value('virt.qemu.paths', 'qemu_dst_bin')
+    QEMU_DST_BIN = settings.get_value('virt.qemu.paths', 'qemu_dst_bin')
 except SettingsError:
     try:
-        qemu_dst = path.get_qemu_dst_binary()
+        QEMU_DST_BIN = path.get_qemu_dst_binary()
     except path.QEMUCmdNotFoundError:
-        qemu_dst = 'qemu'
+        pass
 
+#: The name or path of the qemu-img binary
+QEMU_IMG_BIN = 'qemu-img'
 try:
-    qemu_img_bin = settings.get_value('virt.qemu.paths', 'qemu_img_bin')
+    QEMU_IMG_BIN = settings.get_value('virt.qemu.paths', 'qemu_img_bin')
 except SettingsError:
     try:
-        qemu_img_bin = path.get_qemu_img_binary()
+        QEMU_IMG_BIN = path.get_qemu_img_binary()
     except path.QEMUCmdNotFoundError:
-        qemu_img_bin = 'qemu-img'
+        pass
 
+#: The name or path of the qemu-io binary
+QEMU_IO_BIN = 'qemu-io'
 try:
-    qemu_img_bin = settings.get_value('virt.qemu.paths', 'qemu_io_bin')
+    QEMU_IMG_BIN = settings.get_value('virt.qemu.paths', 'qemu_io_bin')
 except SettingsError:
     try:
         qemu_io_bin = path.get_qemu_io_binary()
     except path.QEMUCmdNotFoundError:
-        qemu_io_bin = 'qemu-io'
+        pass
 
-# The defaults are related to the default image used (JeOS)
+#: The path to the guest image to be used
+GUEST_IMAGE_PATH = ''
 try:
-    guest_image_path = settings.get_value('virt.guest', 'image_path')
+    GUEST_IMAGE_PATH = settings.get_value('virt.guest', 'image_path')
 except SettingsError:
-    guest_image_path = data_dir.get_datafile_path('images',
+    GUEST_IMAGE_PATH = data_dir.get_datafile_path('images',
                                                   'jeos-25-64.qcow2')
 
-guest_user = settings.get_value('virt.guest', 'user', default='root')
-guest_password = settings.get_value('virt.guest', 'password', default='123456')
+#: The username that will be used when trying to log on to guest VMs
+GUEST_USER = settings.get_value('virt.guest', 'user', default='root')
 
-disable_restore_image_test = settings.get_value('virt.restore', 'disable_for_test', default=False, key_type=bool)
-disable_restore_image_job = settings.get_value('virt.restore', 'disable_for_job', default=False, key_type=bool)
+#: The password that will be used when trying to log on to guests VMs
+GUEST_PASSWORD = settings.get_value('virt.guest', 'password', default='123456')
 
-screendump_thread_enable = settings.get_value('virt.screendumps', 'enable', default=False, key_type=bool)
-screendump_thread_interval = settings.get_value('virt.screendumps', 'interval', default=0.5, key_type=float)
+#: If the restoration of the guest image should be disabled between tests
+DISABLE_RESTORE_IMAGE_TEST = settings.get_value('virt.restore', 'disable_for_test',
+                                                default=False, key_type=bool)
 
-video_encoding_enable = settings.get_value('virt.videos', 'enable', default=False, key_type=bool)
-video_encoding_jpeg_quality = settings.get_value('virt.videos', 'jpeg_conversion_quality', default=95, key_type=int)
+#: If the restoration of the guest image should be disabled between jobs
+DISABLE_RESTORE_IMAGE_JOB = settings.get_value('virt.restore', 'disable_for_job',
+                                               default=False, key_type=bool)
 
-migrate_timeout = settings.get_value('virt.qemu.migrate', 'timeout', default=60.0, key_type=float)
+#: If the screendump thread should be enabled
+SCREENDUMP_THREAD_ENABLE = settings.get_value('virt.screendumps', 'enable',
+                                              default=False, key_type=bool)
+
+#: The interval between screedumps (in seconds)
+SCREENDUMP_THREAD_INTERVAL = settings.get_value('virt.screendumps', 'interval',
+                                                default=0.5, key_type=float)
+
+#: If the video encoding should be enabled
+VIDEO_ENCODING_ENABLE = settings.get_value('virt.videos', 'enable',
+                                           default=False, key_type=bool)
+
+#: The quality of the video encoding
+VIDEO_ENCODING_JPEG_QUALITY = settings.get_value('virt.videos',
+                                                 'jpeg_conversion_quality',
+                                                 default=95, key_type=int)
+
+#: The timeout for migrations
+MIGRATE_TIMEOUT = settings.get_value('virt.qemu.migrate', 'timeout',
+                                     default=60.0, key_type=float)

--- a/avocado_virt/plugins/virt.py
+++ b/avocado_virt/plugins/virt.py
@@ -60,49 +60,45 @@ class VirtRun(CLI):
         virt_parser = run_subcommand_parser.add_argument_group('virtualization '
                                                                'testing arguments')
         virt_parser.add_argument(
-            '--qemu-bin', type=str, default=defaults.qemu_bin,
-            help=('Path to a custom qemu binary to be tested. Current path: %s'
-                  % defaults.qemu_bin))
+            '--qemu-bin', type=str, default=defaults.QEMU_BIN,
+            help=('Path to a custom qemu binary to be tested. Current: '
+                  '%(default)s'))
         virt_parser.add_argument(
-            '--qemu-dst-bin', type=str, default=defaults.qemu_dst,
+            '--qemu-dst-bin', type=str, default=defaults.QEMU_DST_BIN,
             help=('Path to a destination qemu binary to be tested. Used as '
-                  'incoming qemu in migration tests. Current path: %s'
-                  % defaults.qemu_dst))
+                  'incoming QEMU in migration tests. Current: %(default)s'))
         virt_parser.add_argument(
-            '--qemu-img-bin', type=str, default=defaults.qemu_img_bin,
+            '--qemu-img-bin', type=str, default=defaults.QEMU_IMG_BIN,
             help=('Path to a custom qemu-img binary to be tested. '
-                  'Current path: %s' % defaults.qemu_img_bin))
+                  'Current %(default)s'))
         virt_parser.add_argument(
-            '--qemu-io-bin', type=str, default=defaults.qemu_io_bin,
+            '--qemu-io-bin', type=str, default=defaults.QEMU_IO_BIN,
             help=('Path to a custom qemu-io binary to be tested. '
-                  'Current path: %s' % defaults.qemu_io_bin))
+                  'Current: %(default)s'))
         virt_parser.add_argument(
-            '--guest-image-path', type=str, default=defaults.guest_image_path,
-            help=('Path to a guest image to be used in tests. '
-                  'Current path: %s' % defaults.guest_image_path))
+            '--guest-image-path', type=str, default=defaults.GUEST_IMAGE_PATH,
+            help=('Path to a guest image to be used in tests. Current: '
+                  '%(default)s'))
         virt_parser.add_argument(
-            '--guest-user', type=str,
-            default=defaults.guest_user,
-            help=('User that avocado should use for remote logins. Current: %s'
-                  % defaults.guest_user))
+            '--guest-user', type=str, default=defaults.GUEST_USER,
+            help=('User that avocado should use for remote logins. Current: '
+                  '%(default)s'))
         virt_parser.add_argument(
-            '--guest-password', type=str,
-            default=defaults.guest_password,
+            '--guest-password', type=str, default=defaults.GUEST_PASSWORD,
             help=('Password for the user avocado should use for remote logins. '
                   'You may omit this if SSH keys are setup in the guest. '
-                  'Current: %s' % defaults.guest_password))
+                  'Current: %(default)s'))
         virt_parser.add_argument(
             '--take-screendumps', action='store_true',
-            default=defaults.screendump_thread_enable,
+            default=defaults.SCREENDUMP_THREAD_ENABLE,
             help=('Take regular QEMU screendumps (PPMs) from VMs under test. '
-                  'Current: %s' % defaults.screendump_thread_enable))
+                  'Current: %(default)s'))
         if VIDEO_ENCODING_SUPPORT:
             virt_parser.add_argument(
                 '--record-videos', action='store_true',
-                default=defaults.video_encoding_enable,
+                default=defaults.VIDEO_ENCODING_ENABLE,
                 help=('Encode videos from VMs under test. '
-                      'Implies --take-screendumps. Current: %s' %
-                      defaults.video_encoding_enable))
+                      'Implies --take-screendumps. Current: %(default)s'))
         virt_parser.add_argument(
             '--qemu-template', nargs='?', type=FileType('r'),
             help='Create qemu command line from a template')
@@ -124,17 +120,17 @@ class VirtRun(CLI):
         set_value('/plugins/virt/screendumps', 'enable', arg='take_screendumps')
         set_value('/plugins/virt/screendumps', 'interval',
                   'screendump_thread_interval',
-                  value=defaults.screendump_thread_interval)
+                  value=defaults.SCREENDUMP_THREAD_INTERVAL)
         set_value('/plugins/virt/qemu/migrate', 'timeout', 'migrate_timeout',
-                  value=defaults.migrate_timeout)
+                  value=defaults.MIGRATE_TIMEOUT)
         if getattr(app_args, 'qemu_template', False):
             set_value('/plugins/virt/qemu/template', 'contents',
                       value=app_args.qemu_template.read())
         set_value('/plugins/virt/videos', 'enable', arg='record_videos')
         set_value('/plugins/virt/videos', 'jpeg_quality',
-                  value=defaults.video_encoding_jpeg_quality)
+                  value=defaults.VIDEO_ENCODING_JPEG_QUALITY)
         set_value('/plugins/virt/guest', 'disable_restore_image_test',
-                  value=defaults.disable_restore_image_test)
+                  value=defaults.DISABLE_RESTORE_IMAGE_TEST)
 
     def run(self, args):
         def app_using_human_output(args):
@@ -145,8 +141,8 @@ class VirtRun(CLI):
             return True
         self.__add_default_values(args)
 
-        if (not defaults.disable_restore_image_job and
-                defaults.disable_restore_image_test):
+        if (not defaults.DISABLE_RESTORE_IMAGE_JOB and
+                defaults.DISABLE_RESTORE_IMAGE_TEST):
             # Don't restore the image when also restoring image per-test
             drive_file = getattr(args, 'guest_image_path', None)
             compressed_drive_file = drive_file + '.xz'


### PR DESCRIPTION
This introduces a change to the style of the defaults set in
`avocado_virt/defaults.py`, but most importantly, it documents them.

This is the type of setting that will affect most users' experiences,
so it makes sense to publish that information as explicitly as
possible.

Signed-off-by: Cleber Rosa <crosa@redhat.com>