### PR TITLE
test: Override the image on restore image

### DIFF
--- a/avocado_virt/test.py
+++ b/avocado_virt/test.py
@@ -42,7 +42,7 @@ class VirtTest(Test):
                            compressed_drive_file)
             cwd = os.getcwd()
             os.chdir(os.path.dirname(compressed_drive_file))
-            process.run('xz -d %s' %
+            process.run('xz -d -k -f %s' %
                         os.path.basename(compressed_drive_file))
             os.chdir(cwd)
         else:


### PR DESCRIPTION
The `xz` by default fails when the target file already exists and also
removes the `xz` file after successful decompression. Let's add `-f` to
override the existing file and `-k` to keep the original file as that is
the expected behavior of "restore".

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>