### PR TITLE
test: Improve image restore

### DIFF
--- a/avocado_virt/test.py
+++ b/avocado_virt/test.py
@@ -42,7 +42,7 @@ class VirtTest(Test):
                            compressed_drive_file)
             cwd = os.getcwd()
             os.chdir(os.path.dirname(compressed_drive_file))
-            process.run('xz -d %s' %
+            process.run('xz -d --keep --force %s' %
                         os.path.basename(compressed_drive_file))
             os.chdir(cwd)
         else:

--- a/avocado_virt/test.py
+++ b/avocado_virt/test.py
@@ -42,7 +42,7 @@ class VirtTest(Test):
                            compressed_drive_file)
             cwd = os.getcwd()
             os.chdir(os.path.dirname(compressed_drive_file))
-            process.run('xz -d --keep --force %s' %
+            process.run('xz --decompress --keep --force %s' %
                         os.path.basename(compressed_drive_file))
             os.chdir(cwd)
         else:


### PR DESCRIPTION
First commit fixes small bug in _restore_guest_images which fails under some circumstances and the second uses long args to improve readability (suggested in v1 by @apahim)

v1: https://github.com/avocado-framework/avocado-virt/pull/101

Changes:

```yaml
v2: New commit to use long arguments
v2: Use long arguments in existing args as well
```