### PR TITLE
Use avocado variants API and some bugfixes [v2]

### DIFF
--- a/avocado_virt/plugins/virt.py
+++ b/avocado_virt/plugins/virt.py
@@ -107,9 +107,9 @@ class VirtRun(CLI):
         def set_value(path, key, arg=None, value=None):
             if arg:
                 value = getattr(app_args, arg, value)
-            root.get_node(path, True).value[key] = value
+            app_args.avocado_variants.add_default_param("avocado-virt",
+                                                        key, value, path)
 
-        root = app_args.default_avocado_params
         set_value('/plugins/virt/qemu/paths', 'qemu_bin', arg='qemu_bin')
         set_value('/plugins/virt/qemu/paths', 'qemu_dst_bin', arg='qemu_dst_bin')
         set_value('/plugins/virt/qemu/paths', 'qemu_img_bin', arg='qemu_img_bin')

--- a/avocado_virt/plugins/virt_bootstrap.py
+++ b/avocado_virt/plugins/virt_bootstrap.py
@@ -75,10 +75,10 @@ class VirtBootstrap(CLICmd):
             actual_sha1 = crypto.hash_file(filename=jeos_dst_path,
                                            algorithm="sha1")
         else:
-            actual_sha1 = '0'
+            actual_sha1 = 'FILE DOES NOT EXIST LOCALLY'
 
         if actual_sha1 != sha1:
-            if actual_sha1 == '0':
+            if actual_sha1 == 'FILE DOES NOT EXIST LOCALLY':
                 LOG.debug('JeOS could not be found at %s. Downloading '
                           'it (205 MB). Please wait...', jeos_dst_path)
             else:

--- a/avocado_virt/plugins/virt_bootstrap.py
+++ b/avocado_virt/plugins/virt_bootstrap.py
@@ -64,6 +64,7 @@ class VirtBootstrap(CLICmd):
         except Exception, exc:
             LOG.error('Failed to get SHA1 from file: %s', exc)
             fail = True
+            sha1 = "FAILED TO GET DOWNLOADED FROM AVOCADO-PROJECT"
 
         jeos_dst_dir = path.init_dir(os.path.join(data_dir.get_data_dir(),
                                                   'images'))

--- a/avocado_virt/plugins/virt_bootstrap.py
+++ b/avocado_virt/plugins/virt_bootstrap.py
@@ -54,7 +54,8 @@ class VirtBootstrap(CLICmd):
                      "equivalent on your distro) to fix the problem")
             fail = True
 
-        jeos_sha1_url = 'http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS25'
+        jeos_sha1_url = ("https://avocado-project.org/data/assets/jeos/25/"
+                         "SHA1SUM_JEOS25")
         try:
             LOG.debug('Verifying expected SHA1 sum from %s', jeos_sha1_url)
             sha1_file = urllib2.urlopen(jeos_sha1_url)
@@ -84,7 +85,8 @@ class VirtBootstrap(CLICmd):
                 LOG.debug('JeOS at %s is either corrupted or outdated. '
                           'Downloading a new copy (205 MB). '
                           'Please wait...', jeos_dst_path)
-            jeos_url = 'http://assets-avocadoproject.rhcloud.com/static/jeos-25-64.qcow2.xz'
+            jeos_url = ("https://avocado-project.org/data/assets/jeos/25/"
+                        "jeos-25-64.qcow2.xz")
             try:
                 download.url_download(jeos_url, jeos_dst_path)
             except:

--- a/docs/source/GetStartedGuide.rst
+++ b/docs/source/GetStartedGuide.rst
@@ -39,7 +39,7 @@ The output should be similar to::
 
     Probing your system for test requirements
     xz present
-    Verifying expected SHA1 sum from http://assets-avocadoproject.rhcloud.com/static/SHA1SUM_JEOS25
+    Verifying expected SHA1 sum from https://avocado-project.org/data/assets/jeos/25/SHA1SUM_JEOS25
     Expected SHA1 sum: 7f5a440f6eb83577d42f9f68987534b1076967d8
     Compressed JeOS image found in /home/<user>/avocado/data/images/jeos-25-64.qcow2.xz, with proper SHA1
     Uncompressing the JeOS image to restore pristine state. Please wait...


### PR DESCRIPTION
The last commit changes the ways we inject default params, because in https://github.com/avocado-framework/avocado/pull/2449 this old interface is getting removed. The first 3 commits are some bugfixes found while working on this. Even with those fixes I can't really pass the `boot` test because of https://trello.com/c/H2XKgVHo/1246-avocado-virt-add-memory-to-cmdline-to-avoid-guest-issues but with manual adjustments it works well.

v1: https://github.com/avocado-framework/avocado-virt/pull/104

Changes:

```yaml
v2: Fixed typo in "FAILED TO GET DOWNLOADED FROM AVOCADO-PROJECT"
v2: Improved the "FILE DOES NOT EXIST LOCALLY"
v2: Removed the change from 205 to hundreds as it's accurate
```